### PR TITLE
dw_client: added 2 cmdline options, num-retry and retry-period, to re…

### DIFF
--- a/src/common.sh
+++ b/src/common.sh
@@ -22,6 +22,12 @@ client() {
     GCOV_PREFIX=gcov/client$id ./dw_client_debug "$@"
 }
 
+client_bg() {
+    id=$(ps aux | grep dw_client_debug | grep -v grep | wc -l)
+    mkdir -p gcov/client$id
+    GCOV_PREFIX=gcov/client$id ./dw_client_debug "$@" &
+}
+
 strace_client() {
     sleep 0.5
     GCOV_PREFIX=gcov/client strace -f ./dw_client_debug "$@"

--- a/src/test_retry_failure.sh
+++ b/src/test_retry_failure.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+. common.sh
+
+tmp=$(mktemp /tmp/test_retry_failure-XXX.dat)
+
+client_bg --tcp=127.0.0.1:7894 --retry-num 2 --retry-period 200 &> $tmp
+
+sleep 2
+node_bg --tcp=7894
+
+cat $tmp
+cat $tmp | grep -q "Connection to 127.0.0.1:7894 failed:"

--- a/src/test_retry_success.sh
+++ b/src/test_retry_success.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+. common.sh
+
+tmp=$(mktemp /tmp/test_retry_success-XXX.dat)
+
+client_bg --tcp=127.0.0.1:7894 --retry-num 10 --retry-period 1000 &> $tmp
+
+sleep 2
+node_bg --tcp=7894
+
+cat $tmp
+cat $tmp | grep -q "CONN allocated"


### PR DESCRIPTION
…try connecting to the (initial) dw_node multiple times in case of failure. The client is gracefully terminated if the connection is not estabilished. Moreover, these options are also useful for automated testing (issue #30) to avoid "races" between clients and nodes in shell scripts.