### PR TITLE
sched_attr.h: don't define for glibc >= 2.41

### DIFF
--- a/src/sched_attr.h
+++ b/src/sched_attr.h
@@ -1,6 +1,10 @@
 #ifndef __SCHED_ATTR_H__
 #define __SCHED_ATTR_H__
 
+/* sched_attr is already defined in glibc >= 2.41 */
+#if !(defined(__GLIBC__) && defined(__GLIBC_MINOR__) && \
+      ((__GLIBC__ > 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 41)))
+
 #include <sys/syscall.h>
 
 struct sched_attr {
@@ -23,5 +27,7 @@ int sched_setattr(pid_t pid,
 {
     return syscall(SYS_sched_setattr, pid, attr, flags);
 }
+
+#endif
 
 #endif /* __SCHED_ATTR_H__ */


### PR DESCRIPTION
glibc 2.41+ has added definitions for function sched_setattr and struct set_attr, so check for glibc version before defining them.

This fixes building with glibc >= 2.41, while keeping the definitions for older glibc versions or other libc implementations.