### PR TITLE
Add SSL/TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ or writing a configurable amount of data.
 The client provides, at the end of the experiment, all the end-to-end
 processing times for all submitted requests.
 
-The client establishes one or more TCP connections to the server,
-which is capable of handling multiple client connections via epoll(7).
+The client establishes one or more TCP (or optionally, SSL/TLS)
+connections to the server, which is capable of handling multiple client
+connections via epoll(7).
 The client can submit concurrent traffic by spawning multiple threads.
 Furthermore, each thread can emulate different sessions where the
 connection is closed and re-established for each new session.
@@ -136,7 +137,7 @@ NODE/SERVER DOCUMENTATION
 ----------------------------------------------------------------------
 The server `dw_node` supports the following command-line options:
 
-```  -b, --bind-addr=[tcp|udp:[//]][host][:port]```
+```  -b, --bind-addr=[tcp|udp|ssl:[//]][host][:port]```
 
 Set the bind name or IP address, port, and communication protocol. All
 three parts of the argument are optional:
@@ -250,9 +251,10 @@ CLIENT DOCUMENTATION
 ----------------------------------------------------------------------
 The client `dw_client` supports the following command-line options:
 
-```  --to=[tcp|udp:[//]][host][:port]```
+```  --to=[tcp|udp|ssl:[//]][host][:port]```
 
 Set the target node host, port and protocol. All elements can be specified or not, see the description of the -F command-line option above for details.
+Note: if the specified protocol is `ssl`, then the `--non-block` option is forced.
 
 ```  -b, --bind-addr=host[:port]|:port```
 

--- a/examples/local-ssl.sh
+++ b/examples/local-ssl.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# determine script directory and binary directory
+SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
+BINDIR="$SCRIPTDIR/../src"
+
+if [[ ! -x "$BINDIR/dw_node" || ! -x "$BINDIR/dw_client" ]]; then
+    echo "Error: cannot find dw_node or dw_client in $BINDIR. Compile first or adjust path."
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d)"
+echo "Using temp directory: $WORKDIR"
+
+# enable xtrace
+set -x
+
+# 1) generate ephemeral CA, server, and client certs/keys
+cd "$WORKDIR" || exit 1
+
+openssl req -x509 -newkey rsa:2048 -nodes -keyout ca.key -out ca.crt -days 1 -subj "/CN=DistWalkCA"
+
+openssl genrsa -out server.key 2048
+openssl req -new -key server.key -out server.csr -subj "/CN=DistWalkServer" -addext "subjectAltName = IP:127.0.0.1"
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 1
+
+openssl genrsa -out client.key 2048
+openssl req -new -key client.key -out client.csr -subj "/CN=DistWalkClient"
+openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt -days 1
+
+# 2) launch dw_node with SSL and custom ciphers
+"$BINDIR/dw_node" \
+    --bind-addr "ssl://localhost" \
+    --ssl-cert "$WORKDIR/server.crt" \
+    --ssl-key "$WORKDIR/server.key" \
+    --ssl-ca "$WORKDIR/ca.crt" \
+    --ssl-ciphers "ECDHE-RSA-AES256-GCM-SHA384" \
+    --nt 1 \
+    &> "$WORKDIR/dw_node_ssl.log" &
+NODEPID=$!
+sleep 1
+
+# 3) run dw_client with SSL and matching ciphers
+"$BINDIR/dw_client" \
+    --to "ssl://localhost" \
+    --ssl-cert "$WORKDIR/client.crt" \
+    --ssl-key "$WORKDIR/client.key" \
+    --ssl-ca "$WORKDIR/ca.crt" \
+    --ssl-ciphers "ECDHE-RSA-AES256-GCM-SHA384" \
+    -C 1000 \
+    -n 5 \
+    &> "$WORKDIR/dw_client_ssl.log"
+
+# 4) kill dw_node
+kill -SIGINT $NODEPID
+
+# disable xtrace.
+set +x
+
+# output final instructions
+echo "Client finished. Logs in:"
+echo "  $WORKDIR/dw_node_ssl.log"
+echo "  $WORKDIR/dw_client_ssl.log"
+echo "Tail of client log:"
+tail -n 10 "$WORKDIR/dw_client_ssl.log"
+echo "======================================================"
+echo "Temporary cert files and logs are in: $WORKDIR"
+echo "When you're done, run the following command to remove"
+echo "the temporary directory manually:"
+echo "  rm -rf \"$WORKDIR\""
+echo "======================================================"

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,8 +3,8 @@ SHELL=/bin/bash
 CFLAGS=-Wall -O3 
 CFLAGS_DEBUG=-g -DDW_DEBUG -fprofile-arcs -ftest-coverage -fprofile-update=atomic
 CFLAGS_TSAN=-g -O2 -fsanitize=thread
-LDLIBS=-pthread -lm
-LDLIBS_DEBUG=-pthread -lm -lgcov
+LDLIBS=-pthread -lm -lssl -lcrypto
+LDLIBS_DEBUG=-pthread -lm -lssl -lcrypto -lgcov
 
 TEST_PROGRAMS=test_distrib test_distrib_debug test_ccmd test_message test_message_debug test_ccmd_debug test_pqueue test_pqueue_debug test_queue test_queue_debug test_timespec test_timespec_debug
 TSAN_PROGRAMS=dw_client_tsan dw_node_tsan

--- a/src/address_utils.c
+++ b/src/address_utils.c
@@ -80,6 +80,10 @@ void addr_proto_parse(char* arg, char *nodehostport, proto_t *proto) {
             *proto = TCP;
             parse_proto_check = 1;
         }
+        if (strncmp(arg, "ssl", 3) == 0) {
+            *proto = TLS;
+            parse_proto_check = 1;
+        }
 
         if (parse_proto_check) {
             arg += 3;
@@ -104,6 +108,10 @@ void addr_proto_parse(char* arg, char *nodehostport, proto_t *proto) {
         }
         if (strncmp(tok, "tcp:", 4) == 0) {
             *proto = TCP;
+            parse_protocol_check = 1;
+        }
+        if (strncmp(tok, "ssl:", 4) == 0) {
+            *proto = TLS;
             parse_protocol_check = 1;
         }
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -2,19 +2,47 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
 
 #include "connection.h"
 #include "dw_debug.h"
 
 conn_info_t conns[MAX_CONNS];
 
+// helper function to run SSL handshake in a non-blocking way
+// returns 1 if handshake is complete, 0 if handshake is in progress, -1 if an error occured
+int conn_do_ssl_handshake(int conn_id) {
+    conn_info_t *conn = &conns[conn_id];
+
+    if (conn->status != SSL_HANDSHAKE)
+        return 1; // nothing to do
+
+    int ret = conn->ssl_is_server ? SSL_accept(conn->ssl) : SSL_connect(conn->ssl);
+    if (ret <= 0) {
+        int err = SSL_get_error(conn->ssl, ret);
+        if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+            dw_log("SSL handshake in progress on conn_id=%d (WANT_READ/WRITE)\n", conn_id);
+            return 0;  // handshake still in progress
+        }
+        dw_log("SSL handshake error on conn_id=%d: %d\n", conn_id, err);
+        ERR_print_errors_fp(stderr);
+        return -1;
+    }
+    dw_log("SSL handshake complete on conn_id=%d\n", conn_id);
+    conn->ssl_handshake_done = 1;
+    conn->status = READY;
+    return 1;
+}
 
 const char *conn_status_str(conn_status_t s) {
     static const char *status_str[STATUS_NUMBER] = {
         "NOT INIT",
         "READY",
         "SENDING",
-        "CONNECTING"
+        "CONNECTING",
+        "SSL HANDSHAKE",
+        "CLOSE",
     };
     return status_str[s];
 }
@@ -25,6 +53,11 @@ void conn_init() {
         conns[i].send_buf = NULL;
         conns[i].sock = -1;
         conns[i].busy = 0;
+        conns[i].use_ssl = 0;
+        conns[i].ssl = NULL;
+        conns[i].ssl_handshake_done = 0;
+        conns[i].ssl_is_server = 0;
+        pthread_mutex_init(&conns[i].ssl_mtx, NULL);
     }
 }
 
@@ -203,9 +236,21 @@ void conn_free(int conn_id) {
     conns[conn_id].recv_buf = NULL;
     free(conns[conn_id].send_buf);   
     conns[conn_id].send_buf = NULL;
+
+    // clean up SSL if used
+    if (conns[conn_id].use_ssl) {
+        SSL_shutdown(conns[conn_id].ssl);
+        SSL_free(conns[conn_id].ssl);
+        conns[conn_id].ssl = NULL;
+    }
+
     conns[conn_id].status = CLOSE;
     conns[conn_id].sock = -1;
     atomic_store(&conns[conn_id].busy, 0);
+
+    // reset handshake state for this connection
+    conns[conn_id].ssl_handshake_done = 0;
+    conns[conn_id].ssl_is_server = 0;
 }
 
 int conn_alloc(int conn_sock, struct sockaddr_in target, proto_t proto) {
@@ -234,6 +279,10 @@ int conn_alloc(int conn_sock, struct sockaddr_in target, proto_t proto) {
     conns[conn_id].recv_buf = new_recv_buf;
     conns[conn_id].send_buf = new_send_buf;
     conns[conn_id].parent_thread = pthread_self(); 
+    conns[conn_id].use_ssl = 0;
+    conns[conn_id].ssl = NULL;
+    conns[conn_id].ssl_handshake_done = 0;
+    conns[conn_id].ssl_is_server = 0;
 
     dw_log("CONN allocated, conn_id: %d\n", conn_id);
     conns[conn_id].curr_recv_buf = conns[conn_id].recv_buf;
@@ -305,15 +354,92 @@ int conn_start_send(conn_info_t *conn, struct sockaddr_in target) {
     // move end of send operation forward by size bytes
     conn->curr_send_size += m->req_size;
 
-    if (conn->status == CONNECTING || conn->status == NOT_INIT)
+    if (conn->status == CONNECTING || conn->status == SSL_HANDSHAKE || conn->status == NOT_INIT)
         return 0;
     else
         return conn_send(conn);
 }
 
+// wrapper for SSL write that first attempts the handshake in a non-blocking way
+static int conn_ssl_send(conn_info_t *conn) {
+    pthread_mutex_lock(&conn->ssl_mtx);
+
+    int conn_id = conn_get_id_by_ptr(conn);
+
+    ssize_t sent = SSL_write(conn->ssl, conn->curr_send_buf, conn->curr_send_size);
+    dw_log("SEND (SSL) conn_id=%d, curr_send_size=%lu\n", conn_id, conn->curr_send_size);
+    if (sent <= 0) {
+        int err = SSL_get_error(conn->ssl, sent);
+        if (err == SSL_ERROR_WANT_WRITE || err == SSL_ERROR_WANT_READ) {
+            dw_log("SSL_write() got WANT_{WRITE,READ}, ignoring...\n");
+            pthread_mutex_unlock(&conn->ssl_mtx);
+            return 0;
+        }
+        if (err == SSL_ERROR_ZERO_RETURN) {
+            dw_log("SSL connection closed by peer\n");
+            conn->status = CLOSE;
+            pthread_mutex_unlock(&conn->ssl_mtx);
+            return 0;
+        }
+        fprintf(stderr, "SSL_write() error: %d\n", err);
+        ERR_print_errors_fp(stderr);
+        pthread_mutex_unlock(&conn->ssl_mtx);
+        return -1;
+    }
+    dw_log("SEND (SSL) returned: %d\n", (int)sent);
+
+    conn->curr_send_buf += sent;
+    conn->curr_send_size -= sent;
+    if (conn->curr_send_size == 0)
+        conn->curr_send_buf = conn->send_buf;
+
+    pthread_mutex_unlock(&conn->ssl_mtx);
+    return (int)sent;
+}
+
+// wrapper for SSL read that first attempts the handshake in a non-blocking way
+static int conn_ssl_recv(conn_info_t *conn) {
+    pthread_mutex_lock(&conn->ssl_mtx);
+
+    int conn_id = conn_get_id_by_ptr(conn);
+
+    if (conn->status == SSL_HANDSHAKE) {
+        dw_log("Cannot receive: SSL handshake in progress on conn_id=%d\n", conn_id);
+        pthread_mutex_unlock(&conn->ssl_mtx);
+        return 1;
+    }
+
+    ssize_t received = SSL_read(conn->ssl, conn->curr_recv_buf, conn->curr_recv_size);
+    dw_log("RECV (SSL) returned: %d\n", (int)received);
+    if (received == 0) {
+        dw_log("SSL_read() connection closed by remote end\n");
+        pthread_mutex_unlock(&conn->ssl_mtx);
+        return 0;
+    } else if (received < 0) {
+        int err = SSL_get_error(conn->ssl, received);
+        if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+            dw_log("SSL_read() got WANT_{READ,WRITE}, ignoring...\n");
+            pthread_mutex_unlock(&conn->ssl_mtx);
+            return 1;
+        }
+        fprintf(stderr, "SSL_read() error: %d\n", err);
+        ERR_print_errors_fp(stderr);
+        pthread_mutex_unlock(&conn->ssl_mtx);
+        return 0;
+    }
+    conn->curr_recv_buf += received;
+    conn->curr_recv_size -= received;
+    pthread_mutex_unlock(&conn->ssl_mtx);
+    return 1;
+}
+
 int conn_send(conn_info_t *conn) {
     int sock = conn->sock;
     dw_log("SEND conn_id=%d, status=%d (%s), curr_send_size=%lu, sock=%d\n", conn_get_id_by_ptr(conn), conn->status, conn_status_str(conn->status), conn->curr_send_size, sock);
+
+    if (conn->use_ssl)
+        return conn_ssl_send(conn);
+
     ssize_t sent = sendto(sock, conn->curr_send_buf, conn->curr_send_size, MSG_NOSIGNAL, (const struct sockaddr*)&conn->target, sizeof(conn->target));
     if (sent == 0) {
         // TODO: should not even be possible, ignoring
@@ -349,6 +475,10 @@ int conn_send(conn_info_t *conn) {
 int conn_recv(conn_info_t *conn) {
     int sock = conn->sock;
     socklen_t recvsize = sizeof(conn->target);
+
+    if (conn->use_ssl)
+        return conn_ssl_recv(conn);
+
     ssize_t received = recvfrom(sock, conn->curr_recv_buf, conn->curr_recv_size, 0,
                                (struct sockaddr*)&conn->target, (socklen_t*)&recvsize);
     dw_log("RECV returned: %d\n", (int)received);
@@ -365,5 +495,43 @@ int conn_recv(conn_info_t *conn) {
     conn->curr_recv_buf += received;
     conn->curr_recv_size -= received;
 
+    return 1;
+}
+
+int conn_enable_ssl(int conn_id, SSL_CTX *ctx, int is_server) {
+    if (conn_id < 0 || conn_id >= MAX_CONNS)
+        return -1;
+
+    conn_info_t *conn = &conns[conn_id];
+    if (conn->sock < 0) {
+        dw_log("conn_enable_ssl(): invalid socket\n");
+        return -1;
+    }
+    if (conn->use_ssl) {
+        dw_log("conn_enable_ssl(): SSL is already enabled\n");
+        return 0; // already enabled
+    }
+
+    conn->ssl = SSL_new(ctx);
+    if (!conn->ssl) {
+        fprintf(stderr, "SSL_new() failed\n");
+        return -1;
+    }
+    if (!SSL_set_fd(conn->ssl, conn->sock)) {
+        fprintf(stderr, "SSL_set_fd() failed\n");
+        SSL_free(conn->ssl);
+        conn->ssl = NULL;
+        return -1;
+    }
+    if (is_server)
+        SSL_set_accept_state(conn->ssl);
+    else
+        SSL_set_connect_state(conn->ssl);
+
+    conn->use_ssl = 1;
+    conn->ssl_handshake_done = 0;
+    conn->ssl_is_server = is_server;
+    conn->status = SSL_HANDSHAKE;
+    dw_log("SSL enabled on conn_id=%d; handshake pending (state set to SSL_HANDSHAKE)\n", conn_id);
     return 1;
 }

--- a/src/dw_client.c
+++ b/src/dw_client.c
@@ -256,10 +256,8 @@ void *thread_receiver(void *data) {
             dw_log("Connecting to %s:%d (sess_id=%d) ...\n", inet_ntoa((struct in_addr) {serveraddr.sin_addr.s_addr}), ntohs(serveraddr.sin_port), (int) (pkt_i / pkts_per_session));
             int rv = 0;
             for (int conn_try = 1; conn_try <= conn_retry_num + 1; conn_try++) {
-                do {
-                    rv = try_connect(&clientSocket[thread_id], serveraddr);
-                } while (conn_nonblock && rv == -1 && errno == EINPROGRESS);
-                if (rv == 0) {
+                rv = try_connect(&clientSocket[thread_id], serveraddr);
+                if (rv == 0 || (rv == -1 && errno == EINPROGRESS)) {
                     dw_log("CONNECTED after %d attempts\n", conn_try);
                     break;
                 } else {

--- a/src/dw_client.c
+++ b/src/dw_client.c
@@ -14,6 +14,9 @@
 #include <time.h>
 #include <unistd.h>
 #include <argp.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/crypto.h>
 
 #include "dw_debug.h"
 #include "distrib.h"
@@ -29,6 +32,8 @@ __thread char thread_name[16];
 int use_wait_spinning = 0;
 
 queue_t* ccmd; // chain of commands
+
+SSL_CTX *client_ssl_ctx = NULL;
 
 unsigned int default_compute_us = 1000;
 
@@ -62,6 +67,13 @@ struct argp_client_arguments {
     int fwd_scope;
     int branching_degree;
     ccmd_node_t* curr_forward_begin;
+
+    char* ssl_cert;    // --ssl-cert
+    char* ssl_key;     // --ssl-key
+    char* ssl_ca;      // --ssl-ca
+    char* ssl_ciphers; // --ssl-ciphers
+    char* ssl_ca_path; // --ssl-ca-path
+    int ssl_verify;    // --ssl-verify
 } input_args;
 
 #define MAX_THREADS 256
@@ -111,7 +123,7 @@ int try_connect(int* conn_sock, struct sockaddr_in target) {
     /*---- Create the socket. The three arguments are: ----*/
     /* 1) Internet domain 2) Stream socket 3) Default protocol (TCP in
     * this case) */
-    if (proto == TCP) {
+    if (proto == TCP || proto == TLS) {
         sys_check(*conn_sock = socket(AF_INET, SOCK_STREAM | (conn_nonblock ? SOCK_NONBLOCK : 0), 0));
         sys_check(setsockopt(*conn_sock, IPPROTO_TCP,
                             TCP_NODELAY, (void *)&no_delay,
@@ -288,7 +300,41 @@ void *thread_receiver(void *data) {
             /* spawn sender once connection is established */
             int conn_id = conn_alloc(clientSocket[thread_id], serveraddr, proto);
             check(conn_id != -1, "conn_alloc() failed, consider increasing MAX_CONNS");
-            conn_set_status_by_id(conn_id, READY);
+
+            // If the protocol is SSL, do the SSL handshake; else mark it READY
+            if (proto == TLS) {
+                extern SSL_CTX *client_ssl_ctx;  // we define this in main()
+                if (conn_enable_ssl(conn_id, client_ssl_ctx, 0) < 0) {
+                    fprintf(stderr, "SSL handshake failed\n");
+                    close(clientSocket[thread_id]);
+                    conn_free(conn_id);
+                    return 0;
+                }
+
+                // retry handshake for up to 5 seconds in non-blocking mode
+                int rv = 0;
+                for (int hs_retry = 1; hs_retry <= 25; hs_retry++) {
+                    rv = conn_do_ssl_handshake(conn_id);
+                    if (rv == 1) {
+                        dw_log("SSL HANDSHAKE SUCCESSFUL after %d tries\n", hs_retry);
+                        break;
+                    } else if (rv == -1) {
+                        fprintf(stderr, "SSL handshake error on conn_id=%d\n", thr_data.conn_id);
+                        close(clientSocket[thread_id]);
+                        conn_free(conn_id);
+                        return 0;
+                    } else {
+                        usleep(200 * 1000);
+                    }
+                }
+                if (rv == 0) {
+                    fprintf(stderr, "SSL handshake failed after 5 seconds\n");
+                    close(clientSocket[thread_id]);
+                    conn_free(conn_id);
+                    return 0;
+                }
+            } else
+                conn_set_status_by_id(conn_id, READY);
 
             thr_data.conn_id = conn_id;
             thr_data.first_pkt_id = pkt_i;
@@ -417,13 +463,20 @@ enum argp_client_option_keys {
     CONN_RETRY_PERIOD,
     CONN_TIMES,
     CONN_NONBLOCK,
-    STAG_SEND
+    STAG_SEND,
+
+    SSL_CERT_FILE,
+    SSL_KEY_FILE,
+    SSL_CA_FILE,
+    SSL_CIPHERS,
+    SSL_CA_PATH,
+    SSL_VERIFY
 };
 
 static struct argp_option argp_client_options[] = {
     // long name, short name, value name, flag, description
     { "bind-addr",          BIND_ADDR,              "host[:port]|:port",                          0, "Set client bindname and bindport"},
-    { "to",                 TO_OPT_ARG,             "[tcp|udp:[//]][host][:port]",                0, "Set distwalk target node host, port and protocol"},
+    { "to",                 TO_OPT_ARG,             "[tcp|udp|ssl:[//]][host][:port]",            0, "Set distwalk target node host, port and protocol"},
     { "num-pkts",           NUM_PKTS,               "n|auto",                                     0, "Number of packets sent by each thread (across all sessions"},
     { "period",             PERIOD,                 "usec|prob:field=val[,field=val]",            0, "Inter-send period for each thread"},
     { "rate",               RATE,                   "npkt",                                       0, "Packet sending rate (in pkts per sec)"},
@@ -456,6 +509,12 @@ static struct argp_option argp_client_options[] = {
     { "script-filename",    SCRIPT_FILENAME,        "path/to/file",                               0, "Continue reading commands from script file (can be intermixed with regular options)"},
     { "help",               HELP,                    0,                                           0, "Show this help message", 1 },
     { "usage",              USAGE,                   0,                                           0, "Show a short usage message", 1 },
+    { "ssl-cert",           SSL_CERT_FILE,           "FILE",                                      0, "Client SSL certificate file" },
+    { "ssl-key",            SSL_KEY_FILE,            "FILE",                                      0, "Client SSL key file" },
+    { "ssl-ca",             SSL_CA_FILE,             "FILE",                                      0, "Client SSL CA file" },
+    { "ssl-ciphers",        SSL_CIPHERS,             "CIPHERS",                                   0, "Allowed SSL ciphers" },
+    { "ssl-ca-path",        SSL_CA_PATH,             "DIR",                                       0, "Client SSL CA path" },
+    { "ssl-verify",         SSL_VERIFY,              0,                                           0, "Require server certificate verification" },
     { 0 }
 };
 
@@ -480,6 +539,14 @@ static error_t argp_client_parse_opt(int key, char *arg, struct argp_state *stat
         arguments->fwd_scope = 0;
         arguments->branching_degree = 0;
         arguments->curr_forward_begin = NULL;
+
+        arguments->ssl_cert = NULL;
+        arguments->ssl_key = NULL;
+        arguments->ssl_ca = NULL;
+        arguments->ssl_ciphers = NULL;
+        arguments->ssl_ca_path = NULL;
+        arguments->ssl_verify = 0;
+
         break;
     case HELP:
         argp_state_help(state, state->out_stream, ARGP_HELP_STD_HELP);
@@ -739,6 +806,24 @@ static error_t argp_client_parse_opt(int key, char *arg, struct argp_state *stat
         no_delay = atoi(arg);
         check(no_delay == 0 || no_delay == 1);
         break;
+    case SSL_CERT_FILE:
+        arguments->ssl_cert = arg;
+        break;
+    case SSL_KEY_FILE:
+        arguments->ssl_key = arg;
+        break;
+    case SSL_CA_FILE:
+        arguments->ssl_ca = arg;
+        break;
+    case SSL_CIPHERS:
+        arguments->ssl_ciphers = arg;
+        break;
+    case SSL_CA_PATH:
+        arguments->ssl_ca_path = arg;
+        break;
+    case SSL_VERIFY:
+        arguments->ssl_verify = 1;
+        break;
     case ARGP_KEY_END: // post-parsing validity checks
         addr_parse(arguments->clienthostport, &myaddr);
         addr_parse(arguments->nodehostport, &serveraddr);
@@ -854,6 +939,55 @@ int main(int argc, char *argv[]) {
 
     argp_parse(&argp, argc, argv, ARGP_NO_HELP, 0, &input_args);
 
+    // If --to ssl://..., then proto == TLS. Setup the SSL context accordingly:
+    if (proto == TLS) {
+        conn_nonblock = 1;  // match the old behavior of forcing non-block if SSL
+
+        SSL_library_init();
+        SSL_load_error_strings();
+        OpenSSL_add_all_algorithms();
+
+        client_ssl_ctx = SSL_CTX_new(TLS_client_method());
+        if (!client_ssl_ctx) {
+            fprintf(stderr, "Error: cannot create SSL context\n");
+            exit(EXIT_FAILURE);
+        }
+        if (input_args.ssl_ca && input_args.ssl_ca[0]) {
+            if (!SSL_CTX_load_verify_locations(client_ssl_ctx, input_args.ssl_ca, NULL)) {
+                fprintf(stderr, "Error: cannot load CA file '%s'\n", input_args.ssl_ca);
+                exit(EXIT_FAILURE);
+            }
+        }
+        if (input_args.ssl_ca_path && input_args.ssl_ca_path[0]) {
+            if (!SSL_CTX_load_verify_locations(client_ssl_ctx, NULL, input_args.ssl_ca_path)) {
+                fprintf(stderr, "Error: cannot load CA path '%s'\n", input_args.ssl_ca_path);
+                exit(EXIT_FAILURE);
+            }
+        }
+        if (input_args.ssl_cert && input_args.ssl_cert[0]) {
+            if (SSL_CTX_use_certificate_file(client_ssl_ctx, input_args.ssl_cert, SSL_FILETYPE_PEM) <= 0) {
+                fprintf(stderr, "Error: cannot load cert file '%s'\n", input_args.ssl_cert);
+                exit(EXIT_FAILURE);
+            }
+        }
+        if (input_args.ssl_key && input_args.ssl_key[0]) {
+            if (SSL_CTX_use_PrivateKey_file(client_ssl_ctx, input_args.ssl_key, SSL_FILETYPE_PEM) <= 0) {
+                fprintf(stderr, "Error: cannot load key file '%s'\n", input_args.ssl_key);
+                exit(EXIT_FAILURE);
+            }
+        }
+        if (input_args.ssl_ciphers && input_args.ssl_ciphers[0]) {
+            if (!SSL_CTX_set_cipher_list(client_ssl_ctx, input_args.ssl_ciphers)) {
+                fprintf(stderr, "Error: cannot set the desired SSL ciphers '%s'\n", input_args.ssl_ciphers);
+                exit(EXIT_FAILURE);
+            }
+        }
+        if (input_args.ssl_verify) {
+            SSL_CTX_set_verify(client_ssl_ctx, SSL_VERIFY_PEER, NULL);
+            SSL_CTX_set_verify_depth(client_ssl_ctx, 100);
+        }
+    }
+
     printf("Configuration:\n");
     printf("  clienthost=%s\n", input_args.clienthostport);
     printf("  serverhost=%s\n", input_args.nodehostport);
@@ -876,6 +1010,16 @@ int main(int argc, char *argv[]) {
     printf("  num_conn_retries: %d (retry_period: %d ms)\n", conn_retry_num, conn_retry_period_ms);
 
     printf("  request template: ");  ccmd_log(ccmd);
+
+    if (proto == TLS) {
+        printf("  SSL/TLS is enabled.\n");
+        if (input_args.ssl_ca && input_args.ssl_ca[0])      printf("  ssl_ca: %s\n", input_args.ssl_ca);
+        if (input_args.ssl_cert && input_args.ssl_cert[0])  printf("  ssl_cert: %s\n", input_args.ssl_cert);
+        if (input_args.ssl_key && input_args.ssl_key[0])    printf("  ssl_key: %s\n", input_args.ssl_key);
+        if (input_args.ssl_ciphers && input_args.ssl_ciphers[0]) printf("  ssl_ciphers: %s\n", input_args.ssl_ciphers);
+        if (input_args.ssl_ca_path && input_args.ssl_ca_path[0])
+            printf("  ssl_ca_path: %s\n", input_args.ssl_ca_path);
+    }
 
     // Init random number generator
     srand(time(NULL));
@@ -915,5 +1059,12 @@ int main(int argc, char *argv[]) {
     }
     
     ccmd_destroy(&ccmd);
+
+    // cleanup the client SSL context if we created one
+    if (client_ssl_ctx) {
+        SSL_CTX_free(client_ssl_ctx);
+        client_ssl_ctx = NULL;
+    }
+
     return 0;
 }

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -78,8 +78,17 @@ const char* get_event_str(event_t event) {
 #define MAX_THREADS 256
 #define MAX_STORAGE_PATH_STR 100
 
+#define MAX_LISTEN_SOCKETS 16
+static int n_bind_addrs = 0;
+static struct {
+    char nodehostport[MAX_HOSTPORT_STRLEN];
+    proto_t protocol;
+} bind_addrs[MAX_LISTEN_SOCKETS];
+
 typedef struct {
-    int listen_sock;
+    int listen_socks[MAX_LISTEN_SOCKETS];
+    int n_listen_socks;
+
     int timerfd;        // special timerfd to handle forward timeouts
     int statfd;         // special signalfd to print statistics
     dw_poll_t dw_poll;
@@ -1075,16 +1084,19 @@ void* conn_worker(void* args) {
 
     sys_check(sched_setattr(0, &infos->sched_attrs, 0));
 
-    if (accept_mode != AM_PARENT || infos == conn_worker_infos) {
-        // Add listen socket
-        int conn_id = conn_find_sock(infos->listen_sock);
+    if (accept_mode != AM_PARENT || infos == &conn_worker_infos[0]) {
+        for (int i = 0; i < infos->n_listen_socks; i++) {
+            int s = infos->listen_socks[i];
+            if (s < 0) continue;
+            int conn_id = conn_find_sock(s);
 
-        uint64_t aux;
-        if(conn_id == -1) // TCP
-            aux = i2l(LISTEN, infos->listen_sock);
-        else // UDP
-            aux = i2l(SOCKET, conn_id);
-        check(dw_poll_add(&infos->dw_poll, infos->listen_sock, DW_POLLIN, aux) == 0);
+            uint64_t aux;
+            if(conn_id == -1) // TCP
+                aux = i2l(LISTEN, s);
+            else // UDP
+                aux = i2l(SOCKET, conn_id);
+            check(dw_poll_add(&infos->dw_poll, s, DW_POLLIN, aux) == 0);
+        }
     }
 
     // Add termination fd
@@ -1129,7 +1141,7 @@ void* conn_worker(void* args) {
                 struct sockaddr_in addr;
                 socklen_t addr_size = sizeof(addr);
                 int conn_sock;
-                sys_check(conn_sock = accept(infos->listen_sock, (struct sockaddr *)&addr, &addr_size));
+                sys_check(conn_sock = accept(event_data, (struct sockaddr *)&addr, &addr_size));
 
                 dw_log("Accepted connection from: %s:%d\n",
                        inet_ntoa(addr.sin_addr), ntohs(addr.sin_port));
@@ -1247,8 +1259,6 @@ enum argp_node_option_keys {
 };
 
 struct argp_node_arguments {
-    char nodehostport[MAX_HOSTPORT_STRLEN];
-    proto_t protocol;
     int periodic_sync_msec;
     size_t max_storage_size;
     int use_odirect;
@@ -1260,7 +1270,7 @@ struct argp_node_arguments {
 
 static struct argp_option argp_node_options[] = {
     // long name, short name, value name, flag, description
-    {"bind-addr",         BIND_ADDR,        "[tcp|udp:[//]][host][:port]",    0,  "DistWalk node bindname, bindport, and communication protocol"},
+    {"bind-addr",         BIND_ADDR,        "[tcp|udp:[//]][host][:port]",    0,  "DistWalk node bindname, bindport, and communication protocol (can be specified multiple times)"},
     {"accept-mode",       ACCEPT_MODE,      "child|shared|parent",            0,  "Accept mode (per-worker thread, shared or parent-only listening queue)"},
     {"poll-mode",         POLL_MODE,        "epoll|poll|select",              0,  "Poll mode (defaults to epoll)"},
     {"backlog-length",    BACKLOG_LENGTH,   "n",                              0,  "Maximum pending connections queue length"},
@@ -1296,7 +1306,12 @@ static error_t argp_node_parse_opt(int key, char *arg, struct argp_state *state)
         argp_state_help(state, state->out_stream, ARGP_HELP_USAGE | ARGP_HELP_EXIT_OK);
         break;
     case BIND_ADDR:
-        addr_proto_parse(arg, arguments->nodehostport, &arguments->protocol);
+        if (n_bind_addrs >= MAX_LISTEN_SOCKETS) {
+            fprintf(stderr, "Too many --bind-addr options\n");
+            exit(EXIT_FAILURE);
+        }
+        addr_proto_parse(arg, bind_addrs[n_bind_addrs].nodehostport, &bind_addrs[n_bind_addrs].protocol);
+        n_bind_addrs++;
         break;
     case ACCEPT_MODE:
         if (strcmp(arg, "child") == 0)
@@ -1402,41 +1417,37 @@ static error_t argp_node_parse_opt(int key, char *arg, struct argp_state *state)
 
 void init_listen_sock(int i, accept_mode_t accept_mode, proto_t proto, struct sockaddr_in serverAddr) {
     if (accept_mode == AM_CHILD || i == 0) {
+        int lsock;
         if (proto == TCP) {
-            conn_worker_infos[i].listen_sock = socket(AF_INET, SOCK_STREAM, 0);
+            lsock = socket(PF_INET, SOCK_STREAM, 0);
         } else {
-            conn_worker_infos[i].listen_sock = socket(AF_INET, SOCK_DGRAM, 0);
-            int conn_id = conn_alloc(conn_worker_infos[i].listen_sock, serverAddr, UDP);
+            lsock = socket(PF_INET, SOCK_DGRAM, 0);
+            int conn_id = conn_alloc(lsock, serverAddr, UDP);
             conn_set_status_by_id(conn_id, READY);
         }
         int val = 1;
-        sys_check(setsockopt(conn_worker_infos[i].listen_sock, SOL_SOCKET, SO_REUSEADDR, (void *)&val, sizeof(val)));
+        sys_check(setsockopt(lsock, SOL_SOCKET, SO_REUSEADDR, (void *)&val, sizeof(val)));
         if (accept_mode == AM_CHILD)
-            sys_check(setsockopt(conn_worker_infos[i].listen_sock, SOL_SOCKET, SO_REUSEPORT, (void *)&val, sizeof(val)));
+            sys_check(setsockopt(lsock, SOL_SOCKET, SO_REUSEPORT, (void *)&val, sizeof(val)));
 
         /*---- Bind the address struct to the socket ----*/
-        sys_check(bind(conn_worker_infos[i].listen_sock, (struct sockaddr *)&serverAddr,
-                        sizeof(serverAddr)));
+        sys_check(bind(lsock, (struct sockaddr *)&serverAddr, sizeof(serverAddr)));
 
         dw_log("Node bound to %s:%d (with protocol: %s)\n", inet_ntoa(serverAddr.sin_addr), ntohs(serverAddr.sin_port), proto_str(proto));
 
         /*---- Listen on the socket, with 5 max connection requests queued ----*/
         if (proto == TCP)
-            sys_check(listen(conn_worker_infos[i].listen_sock, listen_backlog));
+            sys_check(listen(lsock, listen_backlog));
         dw_log("Accepting new connections (max backlog: %d)...\n", listen_backlog);
+
+        conn_worker_infos[i].listen_socks[conn_worker_infos[i].n_listen_socks++] = lsock;
     } else if (accept_mode == AM_SHARED) {
-        conn_worker_infos[i].listen_sock = conn_worker_infos[0].listen_sock;
+        conn_worker_infos[i].n_listen_socks = conn_worker_infos[0].n_listen_socks;
+        for (int k = 0; k < conn_worker_infos[0].n_listen_socks; k++) {
+            conn_worker_infos[i].listen_socks[k] = conn_worker_infos[0].listen_socks[k];
+        }
     } else if (accept_mode == AM_PARENT) {
-        conn_worker_infos[i].listen_sock = -1;
-    }
-
-    // Auxiliary communication medium
-    if (accept_mode == AM_PARENT) {
-        sys_check(socketpair(AF_LOCAL, SOCK_STREAM, 0, conn_worker_infos[i].dispatchfd));
-
-    } else {
-        conn_worker_infos[i].dispatchfd[0] = -1;
-        conn_worker_infos[i].dispatchfd[1] = -1;
+        conn_worker_infos[i].n_listen_socks = 0;
     }
 }
 
@@ -1445,8 +1456,6 @@ int main(int argc, char *argv[]) {
     struct argp_node_arguments input_args;
     
     // Default argp values
-    strcpy(input_args.nodehostport, DEFAULT_ADDR ":" DEFAULT_PORT);
-    input_args.protocol = TCP;
     input_args.periodic_sync_msec = -1;
     input_args.max_storage_size = 1024 * 1024 * 1024;
     input_args.use_odirect = 0;
@@ -1562,8 +1571,6 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    addr_parse(input_args.nodehostport, &serverAddr);
-
     if (loops_per_usec == 0.0) {
         char *dirname = getenv("HOME");
         if (!dirname)
@@ -1592,12 +1599,13 @@ int main(int argc, char *argv[]) {
     }
     dw_log("Using loops_per_usec: %g\n", loops_per_usec);
 
+    // Initialize conn_worker_infos
     for (int i = 0; i < input_args.num_threads; i++) {
         /*---- Create the socket(s). The three arguments are: ----*/
         /* 1) Internet domain 2) Stream socket 3) Default protocol (TCP in this
         * case) */
 
-        init_listen_sock(i, accept_mode, input_args.protocol, serverAddr);
+        conn_worker_infos[i].n_listen_socks = 0;
 
         check(dw_poll_init(&conn_worker_infos[i].dw_poll, poll_mode) == 0);
         conn_worker_infos[i].timerfd =  timerfd_create(CLOCK_BOOTTIME, TFD_NONBLOCK);
@@ -1626,6 +1634,14 @@ int main(int argc, char *argv[]) {
 
         conn_worker_infos[i].active_conns = 0;
         conn_worker_infos[i].active_reqs = 0;
+
+        // Auxiliary communication medium
+        if (accept_mode == AM_PARENT) {
+            sys_check(socketpair(AF_LOCAL, SOCK_STREAM, 0, conn_worker_infos[i].dispatchfd));
+        } else {
+            conn_worker_infos[i].dispatchfd[0] = -1;
+            conn_worker_infos[i].dispatchfd[1] = -1;
+        }
     }
 
     // Init socks mutex
@@ -1636,6 +1652,21 @@ int main(int argc, char *argv[]) {
     //pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
 
     //sys_check(pthread_mutex_init(&socks_mtx, &attr));
+
+    if (n_bind_addrs == 0) {
+        // user didn't provide --bind-addr => use default
+        n_bind_addrs = 1;
+        strcpy(bind_addrs[0].nodehostport, DEFAULT_ADDR ":" DEFAULT_PORT);
+        bind_addrs[0].protocol = TCP;
+    }
+
+    // For each requested bind-addr, init the listen socket(s)
+    for (int l = 0; l < n_bind_addrs; l++) {
+        addr_parse(bind_addrs[l].nodehostport, &serverAddr);
+        for (int i = 0; i < conn_threads; i++) {
+            init_listen_sock(i, accept_mode, bind_addrs[l].protocol, serverAddr);
+        }
+    }
 
     // Init storage thread
     if (storage_worker_info.storage_info.storage_path[0] != '\0') {

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -328,7 +328,7 @@ command_t *single_start_forward(req_info_t *req, message_t *m, command_t *cmd, d
         }
 
         if (fwd.proto == TCP) {
-            check(dw_poll_add(p_poll, clientSocket, DW_POLLOUT | DW_POLLONESHOT, i2l(CONNECT, fwd_conn_id)) == 0);
+            check(dw_poll_add(p_poll, clientSocket, DW_POLLOUT | DW_POLLIN, i2l(CONNECT, fwd_conn_id)) == 0);
 
             dw_log("connecting to: %s:%d\n", inet_ntoa((struct in_addr) { addr.sin_addr.s_addr }),
                    ntohs(addr.sin_port));

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -22,6 +22,9 @@
 #include <stdbool.h>
 #include <sys/prctl.h>
 #include <argp.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/crypto.h>
 
 #include "dw_debug.h"
 #include "message.h"
@@ -35,6 +38,10 @@
 #include "dw_poll.h"
 
 #define MAX_EVENTS 10
+
+// whether there's at least one bind address with SSL enabled
+int ssl_enable = 0;
+SSL_CTX *server_ssl_ctx = NULL;
 
 static inline uint64_t i2l(uint32_t ln, uint32_t rn) {
     return ((uint64_t) ln) << 32 | rn;
@@ -87,6 +94,7 @@ static struct {
 
 typedef struct {
     int listen_socks[MAX_LISTEN_SOCKETS];
+    proto_t listen_socks_proto[MAX_LISTEN_SOCKETS];
     int n_listen_socks;
 
     int timerfd;        // special timerfd to handle forward timeouts
@@ -319,7 +327,7 @@ command_t *single_start_forward(req_info_t *req, message_t *m, command_t *cmd, d
     if (fwd_conn_id == -1) {
         int clientSocket = 0;
 
-        if (fwd.proto == TCP) {
+        if (fwd.proto == TCP || fwd.proto == TLS) {
             clientSocket = socket(AF_INET, SOCK_STREAM, 0);
             sys_check(setsockopt(clientSocket, IPPROTO_TCP,
                                  TCP_NODELAY, (void *)&no_delay,
@@ -336,11 +344,20 @@ command_t *single_start_forward(req_info_t *req, message_t *m, command_t *cmd, d
             return NULL;
         }
 
-        if (fwd.proto == TCP) {
+        if (fwd.proto == TCP || fwd.proto == TLS) {
             check(dw_poll_add(p_poll, clientSocket, DW_POLLOUT | DW_POLLIN, i2l(CONNECT, fwd_conn_id)) == 0);
 
             dw_log("connecting to: %s:%d\n", inet_ntoa((struct in_addr) { addr.sin_addr.s_addr }),
                    ntohs(addr.sin_port));
+
+            if (fwd.proto == TLS) {
+                if (conn_enable_ssl(fwd_conn_id, server_ssl_ctx, 0) < 0) {
+                    fprintf(stderr, "SSL_connect() failed on forward connection\n");
+                    close(clientSocket);
+                    conn_free(fwd_conn_id);
+                    return NULL;
+                }
+            }
 
             int rv = connect(clientSocket, &addr, sizeof(addr));
             if (rv == -1) {
@@ -351,11 +368,19 @@ command_t *single_start_forward(req_info_t *req, message_t *m, command_t *cmd, d
 
                 dw_log("connect(): %s\n", strerror(errno));
                 // normal case of asynchronous connect
-                conn_set_status_by_id(fwd_conn_id, CONNECTING);
+                if (fwd.proto == TLS) {
+                    conn_set_status_by_id(fwd_conn_id, SSL_HANDSHAKE);
+                } else {
+                    conn_set_status_by_id(fwd_conn_id, CONNECTING);
+                }
             } else {
                 dw_log("connect(): Ready\n");
-                conn_set_status_by_id(fwd_conn_id, READY);
-                infos->active_conns++;
+                if (fwd.proto == TLS) {
+                    conn_set_status_by_id(fwd_conn_id, SSL_HANDSHAKE);
+                } else {
+                    conn_set_status_by_id(fwd_conn_id, READY);
+                    infos->active_conns++;
+                }
             }
         }
     }
@@ -826,6 +851,17 @@ void exec_request(dw_poll_t *p_poll, dw_poll_flags pflags, int conn_id, event_t 
     conn_info_t *conn = conn_get_by_id(conn_id);
     dw_log("event_type=%s, conn_id=%d\n", get_event_str(type), conn_id);
 
+    if (conn->status == SSL_HANDSHAKE) {
+        int hs = conn_do_ssl_handshake(conn_id);
+        if (hs < 0)
+            goto err;
+        else if (hs == 0) {
+            /* handshake still in progress, do not proceed with send/recv */
+            return;
+        }
+        /* handshake is complete => status=READY => continue below */
+    }
+
     if (type == TIMER) {
         handle_timeout(p_poll, infos);
         return;
@@ -1091,7 +1127,7 @@ void* conn_worker(void* args) {
             int conn_id = conn_find_sock(s);
 
             uint64_t aux;
-            if(conn_id == -1) // TCP
+            if(conn_id == -1) // TCP/TLS
                 aux = i2l(LISTEN, s);
             else // UDP
                 aux = i2l(SOCKET, conn_id);
@@ -1137,7 +1173,7 @@ void* conn_worker(void* args) {
             l2i(aux, &event_type, (uint32_t*) &event_data);
             dw_log("event_type=%s, event_data=%d (conn_id if event_type==SOCKET, polled fd otherwise)\n", get_event_str(event_type), event_data);
             
-            if (event_type == LISTEN) { // New connection (TCP)
+            if (event_type == LISTEN) { // New connection (TCP or TLS)
                 struct sockaddr_in addr;
                 socklen_t addr_size = sizeof(addr);
                 int conn_sock;
@@ -1149,14 +1185,38 @@ void* conn_worker(void* args) {
                 sys_check(setsockopt(conn_sock, IPPROTO_TCP, TCP_NODELAY,
                                      (void *)&no_delay, sizeof(no_delay)));
 
-                int conn_id = conn_alloc(conn_sock, addr, TCP);
+                // find the index of the listening socket to read the protocol
+                int sock_index = -1;
+                for (int k = 0; k < infos->n_listen_socks; k++) {
+                    if (infos->listen_socks[k] == event_data) {
+                        sock_index = k;
+                        break;
+                    }
+                }
+                if (sock_index < 0) {
+                    fprintf(stderr, "Error: cannot find listening sock index\n");
+                    close(conn_sock);
+                    continue;
+                }
+                proto_t p = infos->listen_socks_proto[sock_index];
+
+                int conn_id = conn_alloc(conn_sock, addr, p);
                 if (conn_id < 0) {
                     fprintf(stderr, "Could not allocate new conn_info_t, closing...\n");
                     close_and_forget(&infos->dw_poll, conn_sock);
                     continue;
                 }
 
-                conn_set_status_by_id(conn_id, READY);
+                if (p == TLS) {
+                    if (conn_enable_ssl(conn_id, server_ssl_ctx, 1) < 0) {
+                        fprintf(stderr, "SSL_accept() failed on incoming connection\n");
+                        close_and_forget(&infos->dw_poll, conn_sock);
+                        conn_free(conn_id);
+                        continue;
+                    }
+                } else
+                    conn_set_status_by_id(conn_id, READY);
+
                 infos->active_conns++;
                 
                 int next_thread_id = accept_mode == AM_PARENT ? (atomic_fetch_add(&next_thread_cnt, 1) % conn_threads) : (infos - conn_worker_infos);
@@ -1256,6 +1316,12 @@ enum argp_node_option_keys {
     WAIT_SPIN,
     LOOPS_PER_USEC,
     BACKLOG_LENGTH,
+    SSL_CERT_FILE,
+    SSL_KEY_FILE,
+    SSL_CA_FILE,
+    SSL_CIPHERS,
+    SSL_CA_PATH,
+    SSL_VERIFY
 };
 
 struct argp_node_arguments {
@@ -1266,11 +1332,17 @@ struct argp_node_arguments {
     char* thread_affinity_list;
     int num_threads;
     struct sched_attr sched_attrs;
+    char* ssl_cert;
+    char* ssl_key;
+    char* ssl_ca;
+    char* ssl_ciphers;
+    char* ssl_ca_path;
+    int ssl_verify;
 };
 
 static struct argp_option argp_node_options[] = {
     // long name, short name, value name, flag, description
-    {"bind-addr",         BIND_ADDR,        "[tcp|udp:[//]][host][:port]",    0,  "DistWalk node bindname, bindport, and communication protocol (can be specified multiple times)"},
+    {"bind-addr",         BIND_ADDR,        "[tcp|udp|ssl:[//]][host][:port]",0,  "DistWalk node bindname, bindport, and communication protocol (can be specified multiple times)"},
     {"accept-mode",       ACCEPT_MODE,      "child|shared|parent",            0,  "Accept mode (per-worker thread, shared or parent-only listening queue)"},
     {"poll-mode",         POLL_MODE,        "epoll|poll|select",              0,  "Poll mode (defaults to epoll)"},
     {"backlog-length",    BACKLOG_LENGTH,   "n",                              0,  "Maximum pending connections queue length"},
@@ -1290,6 +1362,12 @@ static struct argp_option argp_node_options[] = {
     {"loops-per-usec",    LOOPS_PER_USEC,    "value",                         0,  "Set loops_per_usec calibration parameter (0: handle it automatically in ~/.dw_loops_per_usec; -1: use frequency-invariant mode)"},
     {"help",              HELP,              0,                               0,  "Show this help message", 1 },
     {"usage",             USAGE,             0,                               0,  "Show a short usage message", 1 },
+    {"ssl-cert",          SSL_CERT_FILE,     "FILE",                          0,  "Server SSL certificate file" },
+    {"ssl-key",           SSL_KEY_FILE,      "FILE",                          0,  "Server SSL key file" },
+    {"ssl-ca",            SSL_CA_FILE,       "FILE",                          0,  "Server SSL CA file" },
+    {"ssl-ciphers",       SSL_CIPHERS,       "CIPHERS",                       0,  "Allowed SSL ciphers" },
+    {"ssl-ca-path",       SSL_CA_PATH,       "DIR",                           0,  "Server SSL CA path" },
+    {"ssl-verify",        SSL_VERIFY,        0,                               0,  "Enable peer certificate verification"},
     { 0 }
 };
 
@@ -1409,6 +1487,24 @@ static error_t argp_node_parse_opt(int key, char *arg, struct argp_state *state)
             exit(EXIT_FAILURE);
         }
         break;
+    case SSL_CERT_FILE:
+        arguments->ssl_cert = arg;
+        break;
+    case SSL_KEY_FILE:
+        arguments->ssl_key = arg;
+        break;
+    case SSL_CA_FILE:
+        arguments->ssl_ca = arg;
+        break;
+    case SSL_CIPHERS:
+        arguments->ssl_ciphers = arg;
+        break;
+    case SSL_CA_PATH:
+        arguments->ssl_ca_path = arg;
+        break;
+    case SSL_VERIFY:
+        arguments->ssl_verify = 1;
+        break;
     default:
         return ARGP_ERR_UNKNOWN;
     }
@@ -1418,10 +1514,10 @@ static error_t argp_node_parse_opt(int key, char *arg, struct argp_state *state)
 void init_listen_sock(int i, accept_mode_t accept_mode, proto_t proto, struct sockaddr_in serverAddr) {
     if (accept_mode == AM_CHILD || i == 0) {
         int lsock;
-        if (proto == TCP) {
-            lsock = socket(PF_INET, SOCK_STREAM, 0);
+        if (proto == TCP || proto == TLS) {
+            lsock = socket(AF_INET, SOCK_STREAM, 0);
         } else {
-            lsock = socket(PF_INET, SOCK_DGRAM, 0);
+            lsock = socket(AF_INET, SOCK_DGRAM, 0);
             int conn_id = conn_alloc(lsock, serverAddr, UDP);
             conn_set_status_by_id(conn_id, READY);
         }
@@ -1436,15 +1532,18 @@ void init_listen_sock(int i, accept_mode_t accept_mode, proto_t proto, struct so
         dw_log("Node bound to %s:%d (with protocol: %s)\n", inet_ntoa(serverAddr.sin_addr), ntohs(serverAddr.sin_port), proto_str(proto));
 
         /*---- Listen on the socket, with 5 max connection requests queued ----*/
-        if (proto == TCP)
+        /* For TLS => same as TCP. */
+        if (proto == TCP || proto == TLS)
             sys_check(listen(lsock, listen_backlog));
         dw_log("Accepting new connections (max backlog: %d)...\n", listen_backlog);
 
+        conn_worker_infos[i].listen_socks_proto[conn_worker_infos[i].n_listen_socks] = proto;
         conn_worker_infos[i].listen_socks[conn_worker_infos[i].n_listen_socks++] = lsock;
     } else if (accept_mode == AM_SHARED) {
         conn_worker_infos[i].n_listen_socks = conn_worker_infos[0].n_listen_socks;
         for (int k = 0; k < conn_worker_infos[0].n_listen_socks; k++) {
             conn_worker_infos[i].listen_socks[k] = conn_worker_infos[0].listen_socks[k];
+            conn_worker_infos[i].listen_socks_proto[k] = conn_worker_infos[0].listen_socks_proto[k];
         }
     } else if (accept_mode == AM_PARENT) {
         conn_worker_infos[i].n_listen_socks = 0;
@@ -1463,6 +1562,12 @@ int main(int argc, char *argv[]) {
     input_args.thread_affinity_list = NULL;    
     input_args.num_threads = 1;
     input_args.sched_attrs = (struct sched_attr) { .size = sizeof(struct sched_attr), .sched_policy = SCHED_OTHER, .sched_flags = 0 };
+    input_args.ssl_cert = NULL;
+    input_args.ssl_key = NULL;
+    input_args.ssl_ca = NULL;
+    input_args.ssl_ciphers = NULL;
+    input_args.ssl_ca_path = NULL;
+    input_args.ssl_verify = 0;
 
     char *home_path = getenv("HOME");
     check(home_path != NULL && strlen(home_path) + 10 < sizeof(storage_worker_info.storage_info));
@@ -1526,6 +1631,61 @@ int main(int argc, char *argv[]) {
 
     conn_init();
     req_init();
+
+    // If any bind address has TLS, we set ssl_enable = 1
+    for (int i = 0; i < n_bind_addrs; i++) {
+        if (bind_addrs[i].protocol == TLS) {
+            ssl_enable = 1;
+            break;
+        }
+    }
+
+    // if we have TLS, create an SSL_CTX
+    if (ssl_enable) {
+        SSL_library_init();
+        SSL_load_error_strings();
+        OpenSSL_add_all_algorithms();
+
+        server_ssl_ctx = SSL_CTX_new(TLS_method());
+        if (!server_ssl_ctx) {
+            fprintf(stderr, "Error: cannot create server SSL context\n");
+            exit(EXIT_FAILURE);
+        }
+        if (input_args.ssl_ca && input_args.ssl_ca[0]) {
+            if (!SSL_CTX_load_verify_locations(server_ssl_ctx, input_args.ssl_ca, NULL)) {
+                fprintf(stderr, "Error: cannot load CA file '%s'\n", input_args.ssl_ca);
+                exit(EXIT_FAILURE);
+            }
+        }
+        if (input_args.ssl_ca_path && input_args.ssl_ca_path[0]) {
+            if (!SSL_CTX_load_verify_locations(server_ssl_ctx, NULL, input_args.ssl_ca_path)) {
+                fprintf(stderr, "Error: cannot load CA path '%s'\n", input_args.ssl_ca_path);
+                exit(EXIT_FAILURE);
+            }
+        }
+        if (input_args.ssl_cert && input_args.ssl_cert[0]) {
+            if (SSL_CTX_use_certificate_file(server_ssl_ctx, input_args.ssl_cert, SSL_FILETYPE_PEM) <= 0) {
+                fprintf(stderr, "Error: cannot load cert file '%s'\n", input_args.ssl_cert);
+                exit(EXIT_FAILURE);
+            }
+        }
+        if (input_args.ssl_key && input_args.ssl_key[0]) {
+            if (SSL_CTX_use_PrivateKey_file(server_ssl_ctx, input_args.ssl_key, SSL_FILETYPE_PEM) <= 0) {
+                fprintf(stderr, "Error: cannot load key file '%s'\n", input_args.ssl_key);
+                exit(EXIT_FAILURE);
+            }
+        }
+        if (input_args.ssl_ciphers && input_args.ssl_ciphers[0]) {
+            if (!SSL_CTX_set_cipher_list(server_ssl_ctx, input_args.ssl_ciphers)) {
+                fprintf(stderr, "Error: cannot set the desired SSL ciphers '%s'\n", input_args.ssl_ciphers);
+                exit(EXIT_FAILURE);
+            }
+        }
+        if (input_args.ssl_verify) {
+            SSL_CTX_set_verify(server_ssl_ctx, SSL_VERIFY_PEER, NULL);
+            SSL_CTX_set_verify_depth(server_ssl_ctx, 100);
+        }
+    }
 
     // Open storage file, if any
     if (storage_worker_info.storage_info.storage_path[0] != '\0') {
@@ -1725,6 +1885,12 @@ int main(int argc, char *argv[]) {
             close(conn_worker_infos[i].dispatchfd[0]);
             close(conn_worker_infos[i].dispatchfd[1]);
         }
+    }
+
+    // cleanup server SSL context if allocated
+    if (server_ssl_ctx) {
+        SSL_CTX_free(server_ssl_ctx);
+        server_ssl_ctx = NULL;
     }
 
     return 0;

--- a/src/message.h
+++ b/src/message.h
@@ -12,7 +12,7 @@
 
 typedef enum { COMPUTE, STORE, LOAD, PSKIP, FORWARD_BEGIN, FORWARD_CONTINUE, REPLY, EOM } command_type_t;
 
-typedef enum { UDP, TCP, PROTO_NUMBER } proto_t;
+typedef enum { UDP, TCP, TLS, PROTO_NUMBER } proto_t;
 
 typedef struct {
     uint32_t pkt_size;    // size of forwarded packet


### PR DESCRIPTION
- Fix recv and connect when using non-blocking mode in client
- Poll forward socket for incoming data in node
- Allow multiple bind addresses in node
- Implement optional SSL/TLS mode (new "ssl://" protocol).
- Add non-blocking handshake for client and server using OpenSSL.
- Update client to force non-blocking sockets with SSL, parse new --ssl-* options, and initialize SSL_CTX.
- Update node to accept SSL connections, initialize SSL_CTX, and perform non-blocking SSL_accept.
- Link with -lssl and -lcrypto; update Makefile accordingly.
- Provide a local-ssl.sh example to generate test certificates and run node/client with SSL.
- Update README to document SSL/TLS usage.

Closes https://github.com/tomcucinotta/distwalk/issues/37