### PR TITLE
sendfile feature (addressing #78)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,12 +19,3 @@ test_struct_tsan
 *.gcno 
 *.gcda 
 *.gcov
-*.d
-*_debug*
-test*
-.idea/*
-umls_sendfile_flow*
-dw_store
-dw_proxy
-*.txt
-.github

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,12 @@ test_struct_tsan
 *.gcno 
 *.gcda 
 *.gcov
+*.d
+*_debug*
+test*
+.idea/*
+umls_sendfile_flow*
+dw_store
+dw_proxy
+*.txt
+.github

--- a/script/test_sendfile.sh
+++ b/script/test_sendfile.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+CLIENT="./src/dw_client"
+OUTPUT="adistwalk_results_12_load.csv"
+
+K=20   # number of repetitions per test
+
+# Test sizes (16KB → 16MB)
+SIZES=(16KB 32KB 64KB 128KB 256KB 512KB 1MB 2MB)
+
+SENDFILESIZES=(16KB 32KB 64KB 128KB 256KB 512KB 1MB 2MB 4MB 8MB 16MB)
+
+echo "id,t,elapsed,file_size,useSendfile" > "$OUTPUT"
+
+id=0
+
+run_test() {
+    local size=$1
+    local mode=$2
+
+    if [ "$mode" == "sendfile" ]; then
+        cmd="$CLIENT -R sendfile,$size"
+        flag=1
+    else
+        cmd="$CLIENT -L $size -R $size"
+        flag=0
+    fi
+
+    for ((i=0;i<K;i++)); do
+
+        result=$($cmd 2>/dev/null)
+
+        # isolate the measurement line
+        line=$(echo "$result" | grep "t:")
+
+        t=$(echo "$line" | sed -n 's/.*t: \([0-9]*\) us.*/\1/p')
+        elapsed=$(echo "$line" | sed -n 's/.*elapsed: \([0-9]*\) us.*/\1/p')
+
+        if [[ -n "$t" && -n "$elapsed" ]]; then
+            echo "$id,$t,$elapsed,$size,$flag" >> "$OUTPUT"
+            ((id++))
+        else
+            echo "WARNING: parse failed for $size $mode"
+        fi
+
+        sleep 0.05
+    done
+}
+
+
+for size in "${SIZES[@]}"; do
+    echo "Testing NORMAL mode size=$size"
+    run_test "$size" "normal"
+done
+
+for size in "${SENDFILESIZES[@]}"; do
+    echo "Testing SENDFILE mode size=$size"
+    run_test "$size" "sendfile"
+done
+
+echo "Benchmark complete -> $OUTPUT"

--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -9,7 +9,8 @@
 #include "message.h"
 #include "dw_debug.h"
 
-void ccmd_add(queue_t* q, command_type_t cmd, pd_spec_t *p_pd_spec) {
+
+void ccmd_add_reply(queue_t* q, command_type_t cmd, pd_spec_t *p_pd_spec, reply_mode_t reply_mode) {
     if (!q) {
         printf("ccmd_add() error - Initialize queue first\n");
         exit(EXIT_FAILURE);
@@ -18,12 +19,19 @@ void ccmd_add(queue_t* q, command_type_t cmd, pd_spec_t *p_pd_spec) {
     ccmd_node_t* new_node = calloc(1, sizeof(ccmd_node_t));
     new_node->cmd = cmd;
     new_node->pd_val = *p_pd_spec;
-
+    new_node->resp.mode = reply_mode; // reply mode used for sendfile
+    
     if (queue_size(q) >= 1)
         ccmd_last(q)->next = new_node;
 
     data_t data = { .ptr=new_node };
     queue_enqueue(q, cmd, data);
+}
+
+void ccmd_add(queue_t* q, command_type_t cmd, pd_spec_t *p_pd_spec) {
+    reply_mode_t mode = REPLY_MODE_NORMAL; // default reply mode
+    ccmd_add_reply(q, cmd, p_pd_spec, mode);
+
 }
 
 extern __thread struct drand48_data rnd_buf;
@@ -90,6 +98,7 @@ int ccmd_dump(queue_t* q, message_t* m) {
             case REPLY: 
                 *cmd_get_opts(reply_opts_t, m_cmd_itr) = ccmd_itr->resp;
                 cmd_get_opts(reply_opts_t, m_cmd_itr)->resp_size = pd_sample(&ccmd_itr->pd_val);
+                cmd_get_opts(reply_opts_t, m_cmd_itr)->mode = ccmd_itr->resp.mode;
                 break;
             case PSKIP:
                 drand48_r(&rnd_buf, &x);
@@ -109,7 +118,6 @@ int ccmd_dump(queue_t* q, message_t* m) {
                 exit(EXIT_FAILURE);
         }
         m_cmd_itr = cmd_next(m_cmd_itr);
-        //printf("%s\n", get_command_name(curr->cmd));
         ccmd_itr = ccmd_itr->next;
     }
     if (avail < cmd_type_size(EOM))

--- a/src/ccmd.h
+++ b/src/ccmd.h
@@ -23,6 +23,8 @@ typedef struct ccmd_node_t {
 } ccmd_node_t;
 
 void ccmd_add(queue_t* q, command_type_t cmd, pd_spec_t *p_pd_spec);
+void ccmd_add_reply(queue_t* q, command_type_t cmd, pd_spec_t *p_pd_spec, reply_mode_t reply_mode);
+
 ccmd_node_t *ccmd_skip(ccmd_node_t *curr, int n);
 int ccmd_dump(queue_t* q, message_t* m);
 void ccmd_destroy(queue_t** q);

--- a/src/connection.c
+++ b/src/connection.c
@@ -7,6 +7,11 @@
 
 #include "connection.h"
 #include "dw_debug.h"
+#include <sys/stat.h>
+#include <unistd.h>
+#include <sys/sendfile.h>
+
+
 
 conn_info_t conns[MAX_CONNS];
 
@@ -336,13 +341,46 @@ message_t* conn_prepare_recv_message(conn_info_t *conn) {
     }
     assert(m->req_size >= sizeof(message_t) && m->req_size <= BUF_SIZE);
 
-    dw_log("Got complete ");
+    dw_log("Got complete message of [recv size:%lu (expected %d), ready to process\n", msg_size, m->req_size);
 #ifdef DW_DEBUG
-    msg_log(m, "");
+    //msg_log(m, "");
 #endif
 
     conn->curr_proc_buf += m->req_size;
     return m;
+}
+
+// start sending a message using sendfile, assume the head of the curr_send_buffer is a message_t type
+// returns the number of bytes sent, -1 if an error occured
+int conn_start_sendfile(conn_info_t *conn, struct sockaddr_in target, int fd_sendfile, off_t sendfile_offset, size_t sendfile_size) {
+    // prepare the Header (message_t)
+    message_t *m = (message_t*) conn->send_buf;
+    conn->target = target;
+    
+    m->req_size = sendfile_size;
+
+
+    if (conn->curr_send_size == 0)
+        conn->curr_send_buf = conn->send_buf;
+    
+    // The amount of "buffer" data to send is just the size of the message_t header
+    conn->curr_send_size = sizeof(message_t);
+
+    // init the metadata
+    // we use the copied fd from the storage_worker_info (not using the PIPE fd for sendfile since it does not allow 'piped' file pointers)
+    conn->file_fd = fd_sendfile;
+    conn->file_offset = sendfile_offset;
+    conn->file_remaining = sendfile_size - sizeof(message_t); // we consider the header as part of the file data to be sent, so we subtract its size from the remaining bytes to send
+    
+
+    dw_log("SENDFILE starting, conn_id: %d, offset: %ld, size: %zu\n", 
+           conn_get_id_by_ptr(conn), sendfile_offset, sendfile_size);
+
+    // 3. Jump into the sending logic
+    if (conn->status == CONNECTING || conn->status == SSL_HANDSHAKE || conn->status == NOT_INIT)
+        return 0;
+    
+    return conn_send_v2(conn);
 }
 
 // start sending a message, assume the head of the curr_send_buffer is a message_t type
@@ -470,6 +508,76 @@ int conn_send(conn_info_t *conn) {
     return (int)sent;
 }
 
+// this is the main sending loop for sendfile-based sending, called from conn_start_sendfile and also from DW_POLLOUT events when there is remaining data to send
+int conn_send_v2(conn_info_t *conn) {
+    int sock = conn->sock;
+    ssize_t released = 0;
+
+    // PHASE 1: Send the header (blocking until header is fully sent, then move on to sendfile)
+    while (conn->curr_send_size > 0) {
+        // Use MSG_MORE to tell the kernel: "Don't flush the packet yet, file data is coming!"
+        ssize_t sent = send(sock, conn->curr_send_buf, conn->curr_send_size, 
+                            MSG_NOSIGNAL | MSG_MORE);
+        
+        if (sent <= 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) continue; // try again until we can send the header
+            if (errno == EPIPE || errno == ECONNRESET) { conn->status = CLOSE; return -1; }
+        }
+
+        conn->curr_send_buf += sent;
+        conn->curr_send_size -= sent;
+    }
+
+    // PHASE 2: Send the file body
+    if (conn->file_remaining > 0) {
+        // kernel reads from file_fd at file_offset and updates file_offset automatically
+
+        released = sendfile(sock, conn->file_fd, &conn->file_offset, conn->file_remaining);
+
+        if (released == -1) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                dw_log("sendfile Got EAGAIN or EWOULDBLOCK, ignoring...\n");
+                conn_set_status(conn, SENDING); // indicates that we are in the middle of sending and need to wait for next DW_POLLOUT
+                return 0; 
+            }
+            if (errno == EPIPE || errno == ECONNRESET) {
+                dw_log("sendfile failed, connection closed by remote end conn_id=%d\n", conn_get_id_by_ptr(conn));
+                conn->status = CLOSE;
+                return -1;
+            }
+            fprintf(stderr, "SENDFILE error: %s\n", strerror(errno));
+            return -1;
+        } else {
+            conn->file_remaining -= released;
+
+
+            if (conn->file_remaining > 0) {
+            
+                conn_set_status(conn, SENDING);
+                dw_log("\tsendfile sent %zd bytes, new offset: %ld, REMAINING: %zu, status: %s\n", released, conn->file_offset, conn->file_remaining, conn_status_str(conn_get_status(conn)));
+
+                return 0; // return 0 to wait for next DW_POLLOUT if there is still remaining data to send
+            }
+            dw_log("sendfile sent %zd bytes, new offset: %ld, REMAINING: %zu, status: %s\n", released, conn->file_offset, conn->file_remaining, conn_status_str(conn_get_status(conn)));
+
+        }
+    }
+
+    // PHASE 3: Completion Cleanup
+    if (conn->file_remaining == 0) {
+        dw_log("SENDFILE complete for conn_id=%d\n", conn_get_id_by_ptr(conn));
+
+        // Reset pointers for next request
+        conn->file_fd = -1;
+        conn->file_offset = 0;
+        conn->curr_send_buf = conn->send_buf;
+        conn_set_status(conn, READY);
+        // Note: Do NOT close(conn->file_fd) here because it is the shared storage FD!
+    }
+
+    return 1;
+}
+
 // return 1 if received succesfully, -1 on EAGAIN or EWOULDBLOCK, and 0 on other errors
 int conn_recv(conn_info_t *conn) {
     int sock = conn->sock;
@@ -495,6 +603,18 @@ int conn_recv(conn_info_t *conn) {
     conn->curr_recv_size -= received;
 
     return 1;
+}
+
+
+int conn_flush(conn_info_t *conn)
+{
+    if (conn->reply_mode == REPLY_MODE_NORMAL)
+        return conn_send(conn);
+
+    if (conn->reply_mode == REPLY_MODE_SENDFILE)
+        return conn_send_v2(conn);
+
+    return -1;
 }
 
 int conn_enable_ssl(int conn_id, SSL_CTX *ctx, int is_server) {

--- a/src/connection.c
+++ b/src/connection.c
@@ -341,9 +341,9 @@ message_t* conn_prepare_recv_message(conn_info_t *conn) {
     }
     assert(m->req_size >= sizeof(message_t) && m->req_size <= BUF_SIZE);
 
-    dw_log("Got complete message of [recv size:%lu (expected %d), ready to process\n", msg_size, m->req_size);
+    dw_log("Got complete message of recv size:%lu (expected %d), ready to process\n", msg_size, m->req_size);
 #ifdef DW_DEBUG
-    //msg_log(m, "");
+    msg_log(m, "");
 #endif
 
     conn->curr_proc_buf += m->req_size;

--- a/src/connection.h
+++ b/src/connection.h
@@ -39,6 +39,12 @@ typedef struct {
     unsigned char *curr_send_buf; // curr ptr in send buffer while SENDING
     unsigned long curr_send_size; // size of leftover data to send
 
+        // --- Added for sendfile() support ----
+    int     file_fd;              // storage file fd for sendfile
+    off_t file_offset;            // current offset in the file for sendfile
+    size_t  file_remaining;       // remaining bytes to send from the file
+    reply_mode_t reply_mode;       // whether to use SENDFILE for REPLYs on this connection
+
     req_info_t *req_list;        // request ring buffer
     unsigned int serialize_request;
     pthread_t parent_thread;
@@ -88,8 +94,12 @@ void conn_del_id(int id);
 int conn_del_sock(int sock);
 
 int conn_start_send(conn_info_t *conn, struct sockaddr_in target);
+int conn_start_sendfile(conn_info_t *conn, struct sockaddr_in target, int fd_sendfile, off_t sendfile_offset, size_t sendfile_size);
 int conn_send(conn_info_t *conn);
+int conn_send_v2(conn_info_t *conn);
 int conn_recv(conn_info_t *conn);
+int conn_flush(conn_info_t *conn);
+
 
 int conn_enable_ssl(int conn_id, SSL_CTX *ctx, int is_server);
 int conn_do_ssl_handshake(int conn_id);

--- a/src/dw_client.c
+++ b/src/dw_client.c
@@ -425,7 +425,7 @@ void *thread_receiver(void *data) {
                 }
 
                 #ifdef DW_DEBUG
-                    //msg_log(m, "received message: ");
+                    msg_log(m, "received message: ");
                 #endif
             }
             
@@ -465,7 +465,7 @@ void *thread_receiver(void *data) {
                 thr_data.conn_id = -1;
             }
         }
-        printf("end of while loop for Sent pkts - success: %d, error: %d, timeout: %d, thr_id: %d\n", num_success, num_error, num_timedout, thread_id);
+        dw_log("end of while loop for Sent pkts - success: %d, error: %d, timeout: %d, thr_id: %d\n", num_success, num_error, num_timedout, thread_id);
 
     }
 
@@ -872,7 +872,6 @@ static error_t argp_client_parse_opt(int key, char *arg, struct argp_state *stat
         if (queue_size(ccmd) <= 0) { // edge-case
             ccmd_add_reply(ccmd, REPLY, &val, reply_mode);
 
-            printf("edge case\n");
             break;
         }
 

--- a/src/dw_client.c
+++ b/src/dw_client.c
@@ -270,6 +270,8 @@ void *thread_receiver(void *data) {
     int num_success = 0;
     int num_error = 0;
     int num_timedout = 0;
+    int message_completed = 0;
+
 
     int i_incr = 0;
     int pkt_i;
@@ -356,6 +358,7 @@ void *thread_receiver(void *data) {
                 conn_set_status_by_id(thr_data.conn_id, READY);
 
             thr_data.first_pkt_id = pkt_i;
+            printf("Spawning sender thread for sess_id=%d, first_pkt_id=%d\n", pkt_i / (int)pkts_per_session, pkt_i);
             sys_check(pthread_create(&sender[thread_id], NULL, thread_sender,
                                   (void *)&thr_data));
         }
@@ -364,6 +367,7 @@ void *thread_receiver(void *data) {
         // TODO: support receive of variable reply-size requests
         conn_info_t *conn = conn_get_by_id(thr_data.conn_id);
 
+        /*
         do {
             recv = conn_recv(conn);
             if (recv == 0) {
@@ -379,33 +383,52 @@ void *thread_receiver(void *data) {
 
         while ((m = conn_prepare_recv_message(conn))) {
             dw_log("thread_id: %d\n", thread_id);
+        */
 
-#ifdef DW_DEBUG
-            msg_log(m, "received message: ");
-#endif
+        while (!message_completed) {
 
-            unsigned pkt_id = m->req_id;
-            if (m->status != SUCCESS) {
-                dw_log("REPLY reported an error - %s\n", msg_status_str(m->status));
-
-                if (m->status == ERR)
-                    num_error++;
-                else
-                    num_timedout++;
-                i_incr = 1;
-            } else {
-                struct timespec ts_now;
-                clock_gettime(clk_id, &ts_now);
-                unsigned long usecs = (ts_now.tv_sec - ts_start.tv_sec) * 1000000 +
-                    (ts_now.tv_nsec - ts_start.tv_nsec) / 1000;
-                usecs_elapsed[thread_id][idx(pkt_id)] =
-                    usecs - usecs_send[thread_id][idx(pkt_id)];
-                dw_log("thread_id: %d sess_id: %ld req_id %u elapsed %ld us\n", thread_id, pkt_id / pkts_per_session, pkt_id,
-                       usecs_elapsed[thread_id][idx(pkt_id)]);
-
-                num_success++;
-                i_incr = 1;
+            recv = conn_recv(conn);
+            if (recv <= 0) {
+                printf("Error: cannot read received message\n");
+                unsigned long skip_pkts =
+                    pkts_per_session - (pkt_i % pkts_per_session);
+                printf("Fast-forwarding i by %lu pkts\n", skip_pkts);
+                num_error += skip_pkts;
+                i_incr = skip_pkts;
+                goto skip;
             }
+
+            while ((m = conn_prepare_recv_message(conn))) {
+                
+                unsigned pkt_id = m->req_id;
+                if (m->status != SUCCESS) {
+                    dw_log("REPLY reported an error - %s\n", msg_status_str(m->status));
+
+                    if (m->status == ERR)
+                        num_error++;
+                    else
+                        num_timedout++;
+                    i_incr = 1;
+                } else {
+                    struct timespec ts_now;
+                    clock_gettime(clk_id, &ts_now);
+                    unsigned long usecs = (ts_now.tv_sec - ts_start.tv_sec) * 1000000 +
+                        (ts_now.tv_nsec - ts_start.tv_nsec) / 1000;
+                    usecs_elapsed[thread_id][idx(pkt_id)] =
+                        usecs - usecs_send[thread_id][idx(pkt_id)];
+                    dw_log("thread_id: %d sess_id: %ld req_id %u elapsed %ld us\n", thread_id, pkt_id / pkts_per_session, pkt_id,
+                        usecs_elapsed[thread_id][idx(pkt_id)]);
+
+                    num_success++;
+                    i_incr = 1;
+                    message_completed = 1;
+                }
+
+                #ifdef DW_DEBUG
+                    //msg_log(m, "received message: ");
+                #endif
+            }
+            
         }
 
     skip:
@@ -442,6 +465,8 @@ void *thread_receiver(void *data) {
                 thr_data.conn_id = -1;
             }
         }
+        printf("end of while loop for Sent pkts - success: %d, error: %d, timeout: %d, thr_id: %d\n", num_success, num_error, num_timedout, thread_id);
+
     }
 
     if (!use_per_session_output) {
@@ -522,7 +547,7 @@ static struct argp_option argp_client_options[] = {
     { "skip",               SKIP_CMD,               "n[,prob=val,every=m]",                       0, "Skip the next n commands with probability val in (0,1.0] (defaults to 1.0), every m requests (defaults to 1)"},
     { "forward",            FORWARD_CMD,            "ip:port[,ip:port,...][,timeout=usec][,retry=n][,nack=n]\n      [,branch]", 0, "Add a FORWARD command to the given ip:port list, specifying optional connection timeout, retries and number of required acks, and whether its a continued/branched multi-forward"},
     { "ps",                 SEND_REQUEST_SIZE,      "nbytes_spec",          0, "Set payload size of sent requests"},
-    { "rs",                 REPLY_CMD,              "nbytes_spec", OPTION_ARG_OPTIONAL, "Add a REPLY command, optionally specifying the payload size"},
+    { "rs",                 REPLY_CMD,              "nbytes_spec", 0, "Add a REPLY command, optionally specifying the payload size"},
     { "num-threads",        NUM_THREADS,            "n",                                          0, "Number of threads dedicated to communication" },
     { "nt",                 NUM_THREADS,            "n", OPTION_ALIAS },
     { "num-sessions",       NUM_SESSIONS,           "n",                                          0, "Number of sessions each thread establishes with the (initial) distwalk node"},
@@ -815,33 +840,55 @@ static error_t argp_client_parse_opt(int key, char *arg, struct argp_state *stat
         check(send_pkt_size_pd.val + TCPIP_HEADERS_SIZE <= BUF_SIZE, "Too big send request size, maximum is %d", BUF_SIZE);
         break;
     case REPLY_CMD: {
-        pd_spec_t val;
+        pd_spec_t val = pd_build_fixed(default_resp_size);
+        reply_mode_t reply_mode = REPLY_MODE_NORMAL;
 
         if (arg == NULL)
             val = pd_build_fixed(default_resp_size);
         else {
-            check(pd_parse_bytes(&val, arg), "Wrong response size specification");
-            val.min = MIN_REPLY_SIZE;
-            val.max = BUF_SIZE;
-            check(val.prob != FIXED || (val.val >= val.min && val.val <= val.max), "Wrong min-max range for response size");
-        }
+            do {
+                if (strncmp(arg, "sendfile", 8) == 0) {
+                    reply_mode = REPLY_MODE_SENDFILE;
+                    arg += 8;
+                } else {
+                    check(pd_parse_bytes(&val, arg),
+                            "Wrong response size specification");
+                    break;
+                }
 
+                if (arg != NULL && *arg == ',')
+                    arg++;
+            } while (arg != NULL && *arg != '\0');
+        }
+        if (pd_is_none(&val))
+            val = pd_build_fixed(default_resp_size);
+        
+        val.min = MIN_REPLY_SIZE;
+        val.max = BUF_SIZE;
+        
+        check(val.prob != FIXED || (val.val >= val.min && val.val <= val.max), "Wrong min-max range for response size");
+        
+        
         if (queue_size(ccmd) <= 0) { // edge-case
-            ccmd_add(ccmd, COMPUTE, &val);
+            ccmd_add_reply(ccmd, REPLY, &val, reply_mode);
+
+            printf("edge case\n");
             break;
         }
 
         if (arguments->fwd_scope <= 0) {
-            if (ccmd_last(ccmd)->cmd == REPLY && ccmd_last(ccmd) != arguments->last_reserved_used) // update last chained reply
+            if (ccmd_last(ccmd)->cmd == REPLY && ccmd_last(ccmd) != arguments->last_reserved_used)  {// update last chained reply
                 ccmd_last(ccmd)->pd_val = val;
-            else // intra-chain reply
-                ccmd_add(ccmd, REPLY, &val);
+            } else {// intra-chain reply
+                ccmd_add_reply(ccmd, REPLY, &val, reply_mode);
+            }
             break;
         }
 
         // Discard last reserved reply and use updated resp size
         queue_dequeue_tail(arguments->reserved_fwd_replies);
-        ccmd_add(ccmd, REPLY, &val);
+        ccmd_add_reply(ccmd, REPLY, &val, reply_mode);
+        ccmd_last(ccmd)->resp.mode = reply_mode; // added reply_mode
         
         arguments->last_reserved_used = ccmd_last(ccmd);
         arguments->fwd_scope--;

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -116,6 +116,9 @@ typedef struct {
     int storefd; // write
     int store_replyfd; // read
 
+    int storage_fd; // shared storage file descriptor for sendfile
+    reply_mode_t reply_mode;
+
     int worker_id;
     int core_id; // core pinning
     struct sched_attr sched_attrs;
@@ -521,6 +524,8 @@ int reply(req_info_t *req, message_t *m, command_t *cmd, conn_worker_info_t* inf
     reply_opts_t *opts = cmd_get_opts(reply_opts_t, cmd);
     assert(m_dst->req_size >= opts->resp_size);
 
+    //printf("Reply opts: %i\n", sizeof(opts));
+
     m_dst->req_id = m->req_id;
     m_dst->req_size = opts->resp_size;
     m_dst->cmds[0].cmd = EOM;
@@ -537,7 +542,28 @@ int reply(req_info_t *req, message_t *m, command_t *cmd, conn_worker_info_t* inf
     struct sockaddr_in target = req->target;
     conn_req_remove(conn, req);
     infos->active_reqs--;
-    return conn_start_send(&conns[conn_id], target);
+
+    // added branching here for the two cases
+    //printf("Reply opts: resp_size=%u, mode=%d\n", opts->resp_size, opts->mode);
+    conns[conn_id].reply_mode = opts->mode;
+
+    switch (opts->mode) {
+
+    case REPLY_MODE_SENDFILE:
+
+        //printf("storage_fd=%d, conn_worker_infos[conn_id=%d].storage_fd=%d\n", storage_worker_info.storage_info.storage_fd, conn_id, conn_worker_infos[conn_id].storage_fd);
+
+
+        req->sendfile_fd = storage_worker_info.storage_info.storage_fd;//conn_worker_infos[conn_id].storage_fd; // note! fd must be copied here since req will be freed after this function returns,but the sendfile operation may not be completed yet
+        req->sendfile_offset = 0;
+        req->sendfile_size = opts->resp_size;
+        //printf("dw node REPLY using SENDFILE  (req_id=%d, fd=%d)\n", req->req_id, req->sendfile_fd);
+        return conn_start_sendfile(&conns[conn_id], target, req->sendfile_fd, req->sendfile_offset, req->sendfile_size);
+    
+    case REPLY_MODE_NORMAL:
+    default:
+        return conn_start_send(&conns[conn_id], target); // unchanged 
+    }
 }
 
 void compute_for_freqinv(unsigned long usecs) {
@@ -721,10 +747,23 @@ int process_single_message(req_info_t *req, dw_poll_t *p_poll, conn_worker_info_
             }
             return 0;
         case REPLY:
-            dw_log("Handling REPLY: req_id=%d\n", m->req_id);
             if (conn_get_status_by_id(req->conn_id) != CLOSE && !reply(req, m, cmd, infos)) {
-                fprintf(stderr, "reply() failed, conn_id: %d\n", conn_id);
-                return -1;
+                dw_log("reply() returned, conn_id: %d\n", conn_id);
+                
+                if (conn_get_status_by_id(req->conn_id) == SENDING) {
+                    dw_log("Message req_id=%d is still sending after REPLY, conn_id: %d\n", m->req_id, conn_id);
+                    sys_check(dw_poll_mod(p_poll, conns[req->conn_id].sock, DW_POLLOUT | DW_POLLONESHOT, i2l(SOCKET, conn_id)));
+                    return 1;
+                } else {
+                    dw_log("Closing connection conn_id: %d after failed REPLY\n", conn_id);
+                    close_and_forget(p_poll, conns[conn_id].sock);
+                    return -1;
+                }
+            }
+            if (conn_get_status_by_id(req->conn_id) == SENDING) {
+
+                dw_log("Message req_id=%d is still sending after REPLY, conn_id: %d\n", m->req_id, conn_id);
+                sys_check(dw_poll_mod(p_poll, conns[conn_id].sock, DW_POLLOUT | DW_POLLONESHOT, i2l(SOCKET, conn_id)));
             }
             // any further cmds[] for replied-to hop, not me
             return 1;
@@ -790,6 +829,8 @@ int obtain_messages(int conn_id, dw_poll_t *p_poll, conn_worker_info_t* infos) {
             req->curr_cmd = message_first_cmd(m);
             // process_single_message() may call reply() -> conn_req_remove() -> req_unlink() + defrag -> req and m invalid
             int req_size = m->req_size;
+            dw_log("Received message req_id=%d, size=%d, from %s:%d\n", m->req_id, req_size,
+                   inet_ntoa((struct in_addr) {conns[conn_id].target.sin_addr.s_addr}), ntohs(conns[conn_id].target.sin_port));
             int executed = process_single_message(req, p_poll, infos);
 
             if (executed < 0)
@@ -882,6 +923,8 @@ void handle_timeout(dw_poll_t *p_poll, conn_worker_info_t *infos) {
 void exec_request(dw_poll_t *p_poll, dw_poll_flags pflags, int conn_id, event_t type, conn_worker_info_t* infos) {
     conn_info_t *conn = conn_get_by_id(conn_id);
     dw_log("event_type=%s, conn_id=%d\n", get_event_str(type), conn_id);
+    //printf("event_type=%s, conn_id=%d\n", get_event_str(type), conn_id);
+
 
     if (conn->status == SSL_HANDSHAKE) {
         int hs = conn_do_ssl_handshake(conn_id);
@@ -919,32 +962,36 @@ void exec_request(dw_poll_t *p_poll, dw_poll_flags pflags, int conn_id, event_t 
         infos->active_conns++;
         // we need the send_messages() below to still be tried afterwards
     }
-    if ((pflags & DW_POLLOUT) && conn->curr_send_size > 0 && conn_get_status(conn) != CONNECTING && conn_get_status(conn) != NOT_INIT) {
-        dw_log("calling send_mesg() to conn_id=%d\n", conn_id);
-        if (!conn_send(conn))
+    
+    if (pflags & DW_POLLOUT) {
+        int r = conn_flush(conn);
+
+        if (r < 0)
             goto err;
+
+        if (r == 0) {
+            // still pending
+            dw_log("conn_id=%d, still pending after flush, adding EPOLLOUT\n", conn_id);
+            sys_check(dw_poll_mod(p_poll, conn->sock, DW_POLLOUT | DW_POLLONESHOT, i2l(SOCKET, conn_id)));
+        } else {
+            // finished
+            dw_log("conn_id=%d, flush finished, adding EPOLLIN\n", conn_id);
+            sys_check(dw_poll_mod(p_poll, conn->sock, DW_POLLIN | DW_POLLONESHOT, i2l(SOCKET, conn_id)));
+            conn_set_status(conn, READY);
+            infos->active_conns++;
+        }
     }
+
+
     dw_log("conns[%d].status=%d (%s)\n", conn_id, conn_get_status(conn), conn_status_str(conn_get_status(conn)));
 
     // check whether we have new or leftover messages to process
     dw_log("calling obtain_messages() from conn_id=%d's recv buffer\n", conn_id)
+    //printf("conn_id=%d, curr_send_size=%lu, status=%s\n", conn_id, conn->curr_send_size, conn_status_str(conn_get_status(conn)));
     if (!obtain_messages(conn_id, p_poll, infos))
         goto err;
 
-    if (conn->curr_send_size > 0 && conn_get_status(conn) == READY) {
-        dw_log("adding EPOLLOUT for sock=%d, conn_id=%d, curr_send_size=%lu\n",
-               conns->sock, conn_id, conns->curr_send_size);
-        sys_check(dw_poll_mod(p_poll, conns->sock, DW_POLLIN | DW_POLLOUT, i2l(SOCKET, conn_id)));
-        conn_set_status(conn, SENDING);
-    }
-    if (conn->curr_send_size == 0 && conn_get_status(conn) == SENDING) {
-        dw_log("removing EPOLLOUT for sock=%d, conn_id=%d, curr_send_size=%lu\n",
-               conn->sock, conn_id, conn->curr_send_size);
-        sys_check(dw_poll_mod(p_poll, conns->sock, DW_POLLIN, i2l(SOCKET, conn_id)));
-        conn_set_status(conn, READY);
-        infos->active_conns++;
-    }
-
+    
     return;
 
  err:
@@ -1320,6 +1367,7 @@ void* conn_worker(void* args) {
 
                 break;
             } else {
+                //printf("event_type=%s, event_data=%d (conn_id if event_type==SOCKET, polled fd otherwise)\n", get_event_str(event_type), event_data);
                 exec_request(&infos->dw_poll, pflags, event_data, event_type, infos);
             }
         }
@@ -1765,6 +1813,7 @@ int main(int argc, char *argv[]) {
 
             storage_worker_info.store_replyfd[i] = fds2[i][1]; // write 
             conn_worker_infos[i].store_replyfd = fds2[i][0]; // read
+            conn_worker_infos[i].storage_fd = storage_worker_info.storage_info.storage_fd;
         }
     } else {
         for (int i = 0; i < input_args.num_threads; i++) {

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -524,7 +524,6 @@ int reply(req_info_t *req, message_t *m, command_t *cmd, conn_worker_info_t* inf
     reply_opts_t *opts = cmd_get_opts(reply_opts_t, cmd);
     assert(m_dst->req_size >= opts->resp_size);
 
-    //printf("Reply opts: %i\n", sizeof(opts));
 
     m_dst->req_id = m->req_id;
     m_dst->req_size = opts->resp_size;
@@ -544,20 +543,16 @@ int reply(req_info_t *req, message_t *m, command_t *cmd, conn_worker_info_t* inf
     infos->active_reqs--;
 
     // added branching here for the two cases
-    //printf("Reply opts: resp_size=%u, mode=%d\n", opts->resp_size, opts->mode);
     conns[conn_id].reply_mode = opts->mode;
 
     switch (opts->mode) {
 
     case REPLY_MODE_SENDFILE:
 
-        //printf("storage_fd=%d, conn_worker_infos[conn_id=%d].storage_fd=%d\n", storage_worker_info.storage_info.storage_fd, conn_id, conn_worker_infos[conn_id].storage_fd);
-
-
         req->sendfile_fd = storage_worker_info.storage_info.storage_fd;//conn_worker_infos[conn_id].storage_fd; // note! fd must be copied here since req will be freed after this function returns,but the sendfile operation may not be completed yet
         req->sendfile_offset = 0;
         req->sendfile_size = opts->resp_size;
-        //printf("dw node REPLY using SENDFILE  (req_id=%d, fd=%d)\n", req->req_id, req->sendfile_fd);
+        printf("Reply using sendfile.\n");
         return conn_start_sendfile(&conns[conn_id], target, req->sendfile_fd, req->sendfile_offset, req->sendfile_size);
     
     case REPLY_MODE_NORMAL:
@@ -923,7 +918,6 @@ void handle_timeout(dw_poll_t *p_poll, conn_worker_info_t *infos) {
 void exec_request(dw_poll_t *p_poll, dw_poll_flags pflags, int conn_id, event_t type, conn_worker_info_t* infos) {
     conn_info_t *conn = conn_get_by_id(conn_id);
     dw_log("event_type=%s, conn_id=%d\n", get_event_str(type), conn_id);
-    //printf("event_type=%s, conn_id=%d\n", get_event_str(type), conn_id);
 
 
     if (conn->status == SSL_HANDSHAKE) {
@@ -987,7 +981,6 @@ void exec_request(dw_poll_t *p_poll, dw_poll_flags pflags, int conn_id, event_t 
 
     // check whether we have new or leftover messages to process
     dw_log("calling obtain_messages() from conn_id=%d's recv buffer\n", conn_id)
-    //printf("conn_id=%d, curr_send_size=%lu, status=%s\n", conn_id, conn->curr_send_size, conn_status_str(conn_get_status(conn)));
     if (!obtain_messages(conn_id, p_poll, infos))
         goto err;
 
@@ -1367,7 +1360,6 @@ void* conn_worker(void* args) {
 
                 break;
             } else {
-                //printf("event_type=%s, event_data=%d (conn_id if event_type==SOCKET, polled fd otherwise)\n", get_event_str(event_type), event_data);
                 exec_request(&infos->dw_poll, pflags, event_data, event_type, infos);
             }
         }

--- a/src/message.h
+++ b/src/message.h
@@ -43,8 +43,15 @@ typedef struct {
     uint32_t comp_time_us;
 } comp_opts_t;
 
+// added reply mode options
+typedef enum {
+    REPLY_MODE_NORMAL = 0,
+    REPLY_MODE_SENDFILE = 1,
+} reply_mode_t;
+
 typedef struct {
     uint32_t resp_size;   // REPLY pkt size
+    reply_mode_t mode;   // NORMAL | SENDFILE
 } reply_opts_t;
 
 // TODO: Here we need all quantities to be network-ordered

--- a/src/request.h
+++ b/src/request.h
@@ -24,6 +24,11 @@ struct req_info_t {
     command_t *curr_cmd;
     node_t *timeout_node;
     req_info_t *prev, *next;
+
+    // --- Added for sendfile() support ---
+    int     sendfile_fd;      // storage file fd
+    off_t sendfile_offset;    // starting offset for this specific request
+    size_t  sendfile_size;    // number of bytes to send
 };
 
 extern req_info_t reqs[MAX_REQS];


### PR DESCRIPTION
Add the ability to send data from disk straight to network through the sendfile() syscall. allowing a REPLY to perform also a LOAD beforehand.

This enables faster transfers by letting sendfile feed data from file directly to tcp socket, without userspace intervention. (addressing #78)