### PR TITLE
Dpdk integration

### DIFF
--- a/man/dw_client.1
+++ b/man/dw_client.1
@@ -16,19 +16,39 @@ server. It supports multiple connection modes, protocol types, request compositi
 .SH OPTIONS
 
 .TP
-.BR --to "=[" \fIproto\fR: "[" // "]][" \fIhost\fR "][" :\fIport\fR "]"
-Set the target node host (hostname or IP), port and protocol (one of \fBtcp\fR, \fBudp\fR or \fBssl\fR). All elements can be specified or not: \fIproto\fR defaults to \fBtcp\fR, \fIhost\fR defaults to \fBlocalhost\fR, and \fIport\fR defaults to \fB7891\fR.
+.BR --to "=[" \fIproto\fR: "[" // "]][" \fIhost\fR "][" :\fIport\fR "]  |  dpdk://" \fIMAC\fR
+Set the target node host (hostname or IP), port and protocol (one of \fBtcp\fR, \fBudp\fR, \fBssl\fR or \fBdpdk\fR). All elements can be specified or not: \fIproto\fR defaults to \fBtcp\fR, \fIhost\fR defaults to \fBlocalhost\fR, and \fIport\fR defaults to \fB7891\fR.
 Note: if the specified protocol is
 .B ssl,
 then the
 .B --non-block
 option is forced.
 
+When the protocol is
+.B dpdk
+(requires a binary built with
+.B USE_DPDK=1\fR),
+the argument must be the 6-byte MAC address of the target node, written in the canonical colon-separated form (e.g., \fBdpdk://aa:bb:cc:dd:ee:ff\fR). In this mode the client exchanges raw Ethernet frames (EtherType
+.B 0x88B5\fR)
+with the target, bypassing the kernel network stack; the DPDK port used for TX/RX is the one selected by
+.B --bind-addr\fR.
+
 .TP
 .BR -b,\ --bind-addr "=" \fIhost\fR "[" :\fIport\fR "]"
 .TQ
 .BR -b,\ --bind-addr "=" :\fIport\fR
+.TQ
+.BR -b,\ --bind-addr "=dpdk://[" \fIiface\fR | \fIpci\fR "]"
 Set explicitly the bind address or name, and the bind port, for the client.
+
+When the
+.B dpdk://
+prefix is used (requires a binary built with
+.B USE_DPDK=1\fR),
+the client attaches to a NIC via DPDK instead of opening a socket. The argument is either a kernel interface name (used with the
+.B af_packet
+PMD, no hugepages needed) or a PCI address (e.g., \fB0000:04:00.0\fR) to be bound to a DPDK-compatible user-space driver (\fBvfio-pci\fR or \fBigb_uio\fR). The target node must be reached with
+.B --to=dpdk://\fIMAC\fR\fR.
 
 .TP
 .BR -n,\ \--num-pkts = \fIn\fR|\fIauto\fR
@@ -39,6 +59,12 @@ Set the number of requests sent by each thread (across all sessions). The specia
 Set the number of sessions each client thread establishes with the (initial) distwalk node. The overall number of requests to be submitted, specified with
 .B -n,
 is evenly split across the various sessions. If this option is not used, each thread submits its overall number of requests within a single session.
+
+This option is implicitly forced to 1 when the client is bound to a
+.B dpdk://
+address: DPDK does not open a socket per session — it attaches once to the NIC and exchanges raw Ethernet frames identified by MAC, so the notion of multiple sequential sessions against the same peer does not apply. All
+.B -n
+requests are submitted within the single DPDK attachment.
 
 .TP
 .BR --pso,\ \--per-session-output
@@ -97,6 +123,12 @@ mode.
 .BR --ws,\ \--wait-spin
 Tell each client thread to perform a busy-wait loop instead of blocking, while waiting till the point in time in which the next request is to be sent.
 
+This option is implicitly forced on when the client is bound to a
+.B dpdk://
+address: DPDK Poll Mode Drivers expose the NIC as a user-space ring that must be drained by repeatedly calling
+.B rte_eth_rx_burst()\fR,
+with no interrupt or file-descriptor the thread could block on. 
+
 .TP
 .BR --nano
 Output response times in nanoseconds instead of the default microseconds.
@@ -144,14 +176,25 @@ Set the offset value, or its distribution, for the subsequent
 operations.
 
 .TP
-.BR -F,\ \--forward "=\fIip\fR:\fIport\fR[,\fIip2\fR:\fIport2\fR,...][,timeout=\fIusec\fR][,retry=\fIn\fR][,branch][,nack=\fIn\fR]"
+.BR -F,\ \--forward "=[" \fIproto\fR ://"]" \fIdest\fR "[," \fIdest2\fR ",...][,timeout=\fIusec\fR][,retry=\fIn\fR][,branch][,nack=\fIn\fR]"
 Add a
 .B FORWARD
-operation to the submitted per-request operations list, specifying the ip:port to forward to, the timeout to wait for, and the number of retries in case of failure to receive the
+operation to the submitted per-request operations list, specifying the destination(s) to forward to, the timeout to wait for, and the number of retries in case of failure to receive the
 .B REPLY
 to the
 .B FORWARD.
+Each destination is an
+.I ip:port
+pair for TCP/UDP forwards, or a
+.I MAC
+address (colon-separated, 6 bytes) when
+.I proto
+is
+.B dpdk.
 The host and port specification have defaults similarly to the \fB--to\fR option.
+Note: DPDK forwards are only supported when the forwarding
+.B dw_node
+is launched with a single worker thread (\fB--nt 1\fR), because RSS on the source MAC can route the reply to a worker that does not own the originating request's context.
 This option allows also to specify multiple ip:port receivers. In this case, the
 .B FORWARD
 is performed in parallel to all the specified receivers, and by default all of their
@@ -176,7 +219,30 @@ option is used, then different messages can be forwarded to the different peers,
 .BR -R,\ \--rs [ = \fI[sendfile,]nbytes_spec]\fR
 Add to the list of per-request operations to be submitted a
 .B REPLY
-command, optionally specifying the payload size, in bytes (see below for details on how to specify distributions), or enabling the use of sendfile to perform a joined LOAD+REPLY operation.
+command, optionally specifying the payload size, in bytes (see below for details on how to specify distributions), or enabling the use of sendfile to perform a joined LOAD+REPLY operation. The
+.B sendfile
+sub-option is not compatible with the
+.B dpdk
+protocol.
+
+.TP
+.BR --dpdk-rx-cpu = \fIN\fR
+Pin the client's DPDK receiver loop to CPU core
+.I N
+(used as an EAL lcore). Only meaningful with
+.B --bind-addr=dpdk://\fR.
+Requires a binary built with
+.B USE_DPDK=1\fR.
+If unset, the receiver runs on core 0.
+
+.TP
+.BR --dpdk-tx-cpu = \fIN\fR
+Pin the client's DPDK sender loop to a dedicated CPU core
+.I N
+(used as an EAL lcore). If unset, the sender shares the receiver's core. Requires
+.B --bind-addr=dpdk://
+and a binary built with
+.B USE_DPDK=1\fR.
 
 .TP
 .BR --retry-num = \fIn\fR
@@ -355,6 +421,24 @@ Example:
 .fi
 .RE
 
+
+.SH DPDK MODE
+When
+.B dw_client
+is built with
+.B USE_DPDK=1
+and launched with
+.B --bind-addr=dpdk://\fR,
+the client exchanges raw Ethernet frames (EtherType
+.B 0x88B5\fR)
+directly with the target node, bypassing the kernel network stack. In this mode the target and any FORWARD destinations are identified by their 6-byte MAC addresses. The sender and receiver run as DPDK lcores (see
+.B --dpdk-tx-cpu
+and
+.B --dpdk-rx-cpu\fR);
+the receiver busy-polls the RX queue, so
+.B --ws / --wait-spin
+has no additional effect under DPDK. A single RX/TX queue pair is configured on the port regardless of
+.B --nt\fR.
 
 .SH SEE ALSO
 .BR dw_node (1)

--- a/man/dw_node.1
+++ b/man/dw_node.1
@@ -14,7 +14,7 @@ and optimized disk/storage access for latency-sensitive workloads.
 .SH OPTIONS
 
 .TP
-.BR -b,\ -\-bind-addr "=[ tcp | udp | ssl:[//] ] [ host ] [ :port ]"
+.BR -b,\ -\-bind-addr "=[ tcp | udp | ssl:[//] ] [ host ] [ :port ]  |  dpdk://[\fIiface\fR|\fIpci\fR]"
 Set the bind name or IP address, port, and communication protocol. All three parts of the argument are optional:
 .nf
   - if the protocol is not specified, then TCP is assumed by default
@@ -26,6 +26,19 @@ This option can be used multiple times, to let the same `dw_node` instance bind 
 
 Not using this option, is equivalent to calling dw_node with `-b tcp://localhost:7891`.
 
+When the
+.B dpdk://
+prefix is used (requires a binary built with
+.B USE_DPDK=1\fR),
+the node exchanges raw Ethernet frames (EtherType 0x88B5) via DPDK rather than using the kernel network stack. The argument is either a kernel interface name (used with the
+.B af_packet
+PMD, no hugepages needed) or a PCI address (e.g., \fB0000:04:00.0\fR) to be bound to a DPDK-compatible user-space driver (\fBvfio-pci\fR or \fBigb_uio\fR). In this mode:
+.nf
+  - each worker thread (see --nt) owns one RX/TX queue pair; the NIC distributes traffic across queues using RSS hashing on the source MAC (requires an i40e PF)
+  - the DPDK lcore list used by EAL is built from the CPU set specified with -c/--thread-affinity (one lcore per worker)
+  - at most one dpdk:// bind can be specified per instance (a single DPDK port is attached); it can, however, coexist with additional tcp://, udp:// or ssl:// binds on the same dw_node, which worker threads poll alongside the DPDK RX queue
+.ni
+
 .TP
 .BR --backlog-length = \fIn\fR ", " --bl = \fIn\fR
 Set the maximum number of pending incoming connections, for each bound socket, i.e., the argument used when calling listen(). See also the accept mode option described above.
@@ -36,11 +49,17 @@ Enable or disable the TCP_NODELAY socket option (enabled by default).
 
 .TP
 .BR --nt = \fIn\fR ", " --num-threads = \fIn\fR
-Set the number of worker threads (defaults to one worker thread).
+Set the number of worker threads (defaults to one worker thread). When the node is bound to a
+.B dpdk://
+address, this value also determines the number of RX/TX queue pairs configured on the port and the number of DPDK lcores launched (one worker per queue, pinned via the affinity list).
 
 .TP
 .BR -c,\ \--thread-affinity "=auto|cX,cZ[,cA-cD[:step]]"
 Enable thread-to-core pinning through affinity masks. The mask is specified with the usual core-list syntax, as a comma-separated list of core ranges, with the optional use of a colon followed by a core step in a specified range, if desired. If the number of worker threads (see --nt) is higher than the cores in the affinity list, then the list is reused circularly from the beginning (this allows for pinning 2, 3 or as many threads as desired to a single physical core). The special value "auto" sets and affinity of 0-n, where n is equal to the number of specified threads minus one. By default, no affinity is set for worker threads.
+
+When the node is bound to a
+.B dpdk://
+address, the cores listed here are also passed to DPDK as the EAL lcore list (\fB-l\fR), and each worker thread is launched as a dedicated lcore pinned to its assigned core.
 
 .TP
 .BR --sched-policy "=other[:nice]|rr:rtprio|fifo:rtprio|dl:runtime_us,dline_us"
@@ -60,6 +79,12 @@ Run the node in privileged mode if you wish to use `rr`, `fifo`, `dl` or `other`
 .TP
 .BR --wait-spin,\ \--ws
 Tell each worker thread to perform a busy-wait loop, till the next incoming request on any of the monitored sockets, instead of sleeping. This allows the worker threads to be always ready, so to save wake-up from idle, and context switch overheads, thus it is useful in scenarios seeking extremely low latency. However, it causes each worker thread to take 100% of a CPU, regardless on the amount of traffic hitting it.
+
+This option is implicitly forced on when the node is bound to a
+.B dpdk://
+address: DPDK Poll Mode Drivers expose the NIC as a user-space ring that must be drained by repeatedly calling
+.B rte_eth_rx_burst()\fR,
+with no interrupt or file-descriptor to block on. Letting a worker sleep would therefore stall packet reception on its RX queue, so each conn_worker lcore busy-polls the DPDK queue (and, if present, any coexisting socket fd) on every iteration.
 
 .TP
 .BR --wait-spin-storage,\ \--wss
@@ -104,6 +129,24 @@ Enable direct disk access for LOAD and STORE operations (bypass read/write OS ca
 .BR --sync = \fImsec\fR
 Periodically sync the written data on disk, issueing a fsync() system call on the
 storage file.
+
+.SH DPDK MODE
+When
+.B dw_node
+is built with
+.B USE_DPDK=1
+and launched with a
+.B dpdk://
+bind address, the server uses raw Ethernet frames (EtherType
+.B 0x88B5\fR)
+instead of UDP/TCP/SSL. Clients and peer nodes are identified by their 6-byte MAC address rather than by an IP and port. Under this mode:
+.nf
+  - peers are addressed by MAC, so FORWARD operations issued toward this node must also use the dpdk:// protocol with a MAC destination (see dw_client(1))
+  - in PCI mode, the device must be first bound to vfio-pci (or igb_uio) via dpdk-devbind.py; sufficient hugepages must be available
+  - in af_packet mode, the NIC stays attached to its kernel driver and no hugepages are required
+  - multi-queue RSS on the source MAC is only enabled when --nt > 1 and is currently only supported on Intel i40e Physical Functions (via the rte_pmd_i40e input-set API); on any other PMD/NIC all traffic falls back to queue 0
+  - FORWARD chains between DPDK nodes are not supported when the forwarding node runs with --nt > 1: the reply arrives with the peer's source MAC, which RSS may hash to a different queue than the one that issued the FORWARD, and that worker has no access to the originating request context. Use --nt 1 on any DPDK node that issues DPDK forwards
+.ni
 
 .SH FILES
 .TP

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,8 +17,8 @@ ifeq ($(USE_DPDK),1)
     CFLAGS += $(DPDK_CFLAGS) -DDPDK_ENABLED
     CFLAGS_DEBUG += $(DPDK_CFLAGS) -DDPDK_ENABLED
     CFLAGS_TSAN += $(DPDK_CFLAGS) -DDPDK_ENABLED
-    LDLIBS += $(DPDK_LDFLAGS)
-    LDLIBS_DEBUG += $(DPDK_LDFLAGS)
+    LDLIBS += $(DPDK_LDFLAGS) -lrte_net_i40e
+    LDLIBS_DEBUG += $(DPDK_LDFLAGS) -lrte_net_i40e
 endif
 
 TEST_PROGRAMS=test_distrib test_distrib_debug test_ccmd test_ccmd_debug test_message test_message_debug test_pqueue test_pqueue_debug

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,6 +9,18 @@ CFLAGS_TSAN=-g -Wall -O2 -fsanitize=thread
 LDLIBS=-pthread -lm -lssl -lcrypto
 LDLIBS_DEBUG=-pthread -lm -lssl -lcrypto -lgcov
 
+# Optional DPDK support, adding DPDK flags when enabled as per documentation
+USE_DPDK ?= 0
+ifeq ($(USE_DPDK),1)
+    DPDK_CFLAGS := $(shell pkg-config --cflags libdpdk)
+    DPDK_LDFLAGS := $(shell pkg-config --libs libdpdk)
+    CFLAGS += $(DPDK_CFLAGS) -DDPDK_ENABLED
+    CFLAGS_DEBUG += $(DPDK_CFLAGS) -DDPDK_ENABLED
+    CFLAGS_TSAN += $(DPDK_CFLAGS) -DDPDK_ENABLED
+    LDLIBS += $(DPDK_LDFLAGS)
+    LDLIBS_DEBUG += $(DPDK_LDFLAGS)
+endif
+
 TEST_PROGRAMS=test_distrib test_distrib_debug test_ccmd test_ccmd_debug test_message test_message_debug test_pqueue test_pqueue_debug
 TEST_PROGRAMS+=test_queue test_queue_debug test_timespec test_timespec_debug dw_proxy dw_proxy_debug
 TSAN_PROGRAMS=dw_client_tsan dw_node_tsan
@@ -18,6 +30,12 @@ MAIN_PROGRAMS=dw_client dw_node
 DW_CLIENT_SOURCES=dw_client.c ccmd.c distrib.c thread_affinity.c connection.c request.c message.c queue.c address_utils.c
 DW_NODE_SOURCES=dw_node.c thread_affinity.c priority_queue.c request.c connection.c message.c address_utils.c dw_poll.c
 DW_PROXY_SOURCES=dw_proxy.c address_utils.c
+
+# Add DPDK source file when enabled
+ifeq ($(USE_DPDK),1)
+    DW_CLIENT_SOURCES += dw_dpdk.c
+    DW_NODE_SOURCES += dw_dpdk.c
+endif
 
 TEST_SCRIPTS=$(wildcard test_*.sh)
 TOOLS=bash gcovr

--- a/src/address_utils.c
+++ b/src/address_utils.c
@@ -75,18 +75,22 @@ void addr_proto_parse(char* arg, char *nodehostport, proto_t *proto) {
         if (strncmp(arg, "udp", 3) == 0) {
             *proto = UDP;
             parse_proto_check = 1;
-        }
-        if (strncmp(arg, "tcp", 3) == 0) {
+            arg += 3;
+        } else if (strncmp(arg, "tcp", 3) == 0) {
             *proto = TCP;
             parse_proto_check = 1;
-        }
-        if (strncmp(arg, "ssl", 3) == 0) {
+            arg += 3;
+        } else if (strncmp(arg, "ssl", 3) == 0) {
             *proto = TLS;
             parse_proto_check = 1;
+            arg += 3;
+        } else if (strncmp(arg, "dpdk", 4) == 0) {
+            *proto = DPDK;
+            parse_proto_check = 1;
+            arg += 4;
         }
 
         if (parse_proto_check) {
-            arg += 3;
             if (arg[0] == ':') {
                 arg++;
             }
@@ -102,21 +106,27 @@ void addr_proto_parse(char* arg, char *nodehostport, proto_t *proto) {
         check(tok != NULL);
 
         int parse_protocol_check = 0;
+        int proto_len = 0;
         if (strncmp(tok, "udp:", 4) == 0) {
             *proto = UDP;
             parse_protocol_check = 1;
-        }
-        if (strncmp(tok, "tcp:", 4) == 0) {
+            proto_len = 4;
+        } else if (strncmp(tok, "tcp:", 4) == 0) {
             *proto = TCP;
             parse_protocol_check = 1;
-        }
-        if (strncmp(tok, "ssl:", 4) == 0) {
+            proto_len = 4;
+        } else if (strncmp(tok, "ssl:", 4) == 0) {
             *proto = TLS;
             parse_protocol_check = 1;
+            proto_len = 4;
+        } else if (strncmp(tok, "dpdk:", 5) == 0) {
+            *proto = DPDK;
+            parse_protocol_check = 1;
+            proto_len = 5;
         }
 
         if (parse_protocol_check) {
-            tok += 4;
+            tok += proto_len;
             check(tok[0] == '\0');
 
             tok = strtok_r(NULL, "//", &reserve);

--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -166,13 +166,26 @@ void ccmd_log(queue_t* q) {
                     sprintf(opts, "%d", curr->n_skip);
                 break;
             case FORWARD_BEGIN:
-                sprintf(opts, "%s://%s:%d,%sb,retries=%d,timeout=%d,branched=%d,nack=%d", curr->fwd.proto == TCP ? "tcp" : "udp", 
+                if (curr->fwd.proto == DPDK)
+                    sprintf(opts, "dpdk://%02x:%02x:%02x:%02x:%02x:%02x,%sb,retries=%d,timeout=%d,branched=%d,nack=%d",
+                            curr->fwd.fwd_addr[0], curr->fwd.fwd_addr[1], curr->fwd.fwd_addr[2],
+                            curr->fwd.fwd_addr[3], curr->fwd.fwd_addr[4], curr->fwd.fwd_addr[5],
+                            pd_str(&curr->pd_val), curr->fwd.retries, curr->fwd.timeout, curr->fwd.branched,
+                            curr->fwd.n_ack);
+                else
+                    sprintf(opts, "%s://%s:%d,%sb,retries=%d,timeout=%d,branched=%d,nack=%d", curr->fwd.proto == TCP ? "tcp" : "udp", 
                                                                     inet_ntoa((struct in_addr) {curr->fwd.fwd_host}), ntohs(curr->fwd.fwd_port), 
                                                                     pd_str(&curr->pd_val), curr->fwd.retries, curr->fwd.timeout, curr->fwd.branched,
                                                                     curr->fwd.n_ack);
                 break;
             case FORWARD_CONTINUE:
-                sprintf(opts, "%s://%s:%d,%sb", curr->fwd.proto == TCP ? "tcp" : "udp", 
+                if (curr->fwd.proto == DPDK)
+                    sprintf(opts, "dpdk://%02x:%02x:%02x:%02x:%02x:%02x,%sb",
+                            curr->fwd.fwd_addr[0], curr->fwd.fwd_addr[1], curr->fwd.fwd_addr[2],
+                            curr->fwd.fwd_addr[3], curr->fwd.fwd_addr[4], curr->fwd.fwd_addr[5],
+                            pd_str(&curr->pd_val));
+                else
+                    sprintf(opts, "%s://%s:%d,%sb", curr->fwd.proto == TCP ? "tcp" : "udp", 
                                                                                   inet_ntoa((struct in_addr) {curr->fwd.fwd_host}), ntohs(curr->fwd.fwd_port), 
                                                                                   pd_str(&curr->pd_val));
                 break;

--- a/src/connection.c
+++ b/src/connection.c
@@ -136,7 +136,8 @@ static void conn_reset(conn_info_t *conn) {
 }
 
 req_info_t* conn_req_remove(conn_info_t *conn, req_info_t *req) {
-    if (conn->enable_defrag) {
+    // skip defrag if message_ptr is outside recv_buf (DPDK zero-copy from mbuf)
+    if (conn->enable_defrag && req->message_ptr >= conn->recv_buf && req->message_ptr < conn->recv_buf + BUF_SIZE) {
         unsigned long req_size = req_get_message(req)->req_size;
         unsigned long leftover = conn->curr_recv_buf - (req->message_ptr + req_size);
     
@@ -171,6 +172,10 @@ int conn_find_existing(struct sockaddr_in target, proto_t proto) {
 
     pthread_t curr_thread = pthread_self();
     for (int i = 0; i < MAX_CONNS; i++) {
+        if (proto == DPDK && conns[i].proto == DPDK && conns[i].parent_thread == curr_thread) {
+            rv = i;
+            break;
+        }
         if (conns[i].sock == -1)
             continue;
         if (proto == UDP && conns[i].parent_thread == curr_thread) {

--- a/src/connection.h
+++ b/src/connection.h
@@ -9,6 +9,10 @@
 #include "message.h"
 #include "request.h"
 
+#ifdef DPDK_ENABLED
+#include "dw_dpdk.h"
+#endif
+
 #define MAX_CONNS 8192
 
 typedef enum {
@@ -51,6 +55,12 @@ typedef struct {
     atomic_int busy;             // 1 if conn is allocated, 0 otherwise
     
     int enable_defrag;            // Defragment receive buffer to reduce memory usage
+
+#ifdef DPDK_ENABLED
+    struct rte_mbuf *rx_mbufs[RX_BURST_SIZE];
+    struct rte_mbuf *tx_mbufs[TX_BURST_SIZE];
+    uint16_t tx_count;
+#endif
 
     // SSL/TLS support
     int use_ssl;                  // 1 if SSL is enabled for this connection

--- a/src/dw_client.c
+++ b/src/dw_client.c
@@ -27,6 +27,14 @@
 #include "address_utils.h"
 #include "queue.h"
 
+#ifdef DPDK_ENABLED
+#include "dw_dpdk.h"
+#include "thread_affinity.h"
+#include <rte_lcore.h>
+#include <rte_launch.h>
+static unsigned dpdk_tx_lcore = RTE_MAX_LCORE;
+#endif
+
 //__thread char thread_name[16];
 
 int use_wait_spinning = 0;
@@ -56,6 +64,11 @@ int conn_times = 0;
 int staggered_send = 0;
 int seed = -1;
 
+#ifdef DPDK_ENABLED
+static int use_dpdk = 0;
+static uint8_t dpdk_dest_mac[6];
+#endif
+
 struct argp_client_arguments {
     int num_sessions;
     int num_threads;
@@ -77,6 +90,8 @@ struct argp_client_arguments {
     char* ssl_ciphers; // --ssl-ciphers
     char* ssl_ca_path; // --ssl-ca-path
     int ssl_verify;    // --ssl-verify
+    int dpdk_tx_cpu;   // CPU for sender thread
+    int dpdk_rx_cpu;   // CPU for receiver thread
 } input_args;
 
 #define MAX_THREADS 256
@@ -528,13 +543,15 @@ enum argp_client_option_keys {
     SSL_CIPHERS,
     SSL_CA_PATH,
     SSL_VERIFY,
-    NANO_OUTPUT
+    NANO_OUTPUT,
+    DPDK_TX_CPU,
+    DPDK_RX_CPU
 };
 
 static struct argp_option argp_client_options[] = {
     // long name, short name, value name, flag, description
-    { "bind-addr",          BIND_ADDR,              "host[:port]|:port",                          0, "Set client bindname and bindport"},
-    { "to",                 TO_OPT_ARG,             "[tcp|udp|ssl:[//]][host][:port]",            0, "Set distwalk target node host, port and protocol"},
+    { "bind-addr",          BIND_ADDR,              "host[:port]|:port | dpdk://[iface|pci]",     0, "Set client bindname, bindport or a DPDK bind interface"},
+    { "to",                 TO_OPT_ARG,             "[tcp|udp|ssl:[//]][host][:port] | dpdk://mac",        0, "Set distwalk target node address and protocol"},
     { "num-pkts",           NUM_PKTS,               "n|auto",                                     0, "Number of packets sent by each thread (across all sessions"},
     { "period",             PERIOD,                 "usec_spec",            0, "Inter-send period for each thread"},
     { "rate",               RATE,                   "npkt",                                       0, "Packet sending rate (in pkts per sec)"},
@@ -577,6 +594,8 @@ static struct argp_option argp_client_options[] = {
     { "ssl-ca-path",        SSL_CA_PATH,             "dir",                                       0, "Client SSL CA path" },
     { "ssl-verify",         SSL_VERIFY,              0,                                           0, "Require server certificate verification" },
     { "nano",               NANO_OUTPUT,             0,                                           0, "Output response times in nanoseconds (default: microseconds)" },
+    { "dpdk-tx-cpu",        DPDK_TX_CPU,             "N",                                         0, "CPU core for DPDK sender thread" },
+    { "dpdk-rx-cpu",        DPDK_RX_CPU,             "N",                                         0, "CPU core for DPDK receiver thread" },
     { 0 }
 };
 
@@ -623,7 +642,7 @@ static error_t argp_client_parse_opt(int key, char *arg, struct argp_state *stat
         break;
     case BIND_ADDR:
         check(strlen(arg) < MAX_HOSTPORT_STRLEN, "Too long host:port argument to %c option", BIND_ADDR);
-        strcpy(arguments->clienthostport, arg);
+        addr_proto_parse(arg, arguments->clienthostport, &(proto_t){TCP}); // strip protocol prefix for DPDK
         break;
     case TO_OPT_ARG:
         check(strlen(arg) < MAX_HOSTPORT_STRLEN, "Too long host:port argument to --to option");
@@ -801,7 +820,6 @@ static error_t argp_client_parse_opt(int key, char *arg, struct argp_state *stat
             proto_t fwd_proto = TCP;
 
             addr_proto_parse(tok, fwdhostport, &fwd_proto);
-            addr_parse(fwdhostport, &fwd_addr);
 
             ccmd_add(ccmd, FORWARD_BEGIN, &fwd_val); // may need to be changed to FORWARD_CONTINUE later
 
@@ -810,11 +828,21 @@ static error_t argp_client_parse_opt(int key, char *arg, struct argp_state *stat
             if (multi_fwds == 0) // keep track of the first forward operation in this subcontext
                 fwd_itr_start = ccmd_last(ccmd);
 
-            // Static params
-            ccmd_last(ccmd)->fwd.fwd_port = fwd_addr.sin_port;
-            ccmd_last(ccmd)->fwd.fwd_host = fwd_addr.sin_addr.s_addr;
             ccmd_last(ccmd)->fwd.on_fail_skip = 1;
             ccmd_last(ccmd)->fwd.proto = fwd_proto;
+
+            if (fwd_proto == DPDK) {
+                unsigned int mac[6];
+                int n = sscanf(fwdhostport, "%x:%x:%x:%x:%x:%x",
+                               &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
+                check(n == 6, "Invalid MAC address for DPDK forward: %s", fwdhostport);
+                for (int j = 0; j < 6; j++)
+                    ccmd_last(ccmd)->fwd.fwd_addr[j] = (uint8_t)mac[j];
+            } else {
+                addr_parse(fwdhostport, &fwd_addr);
+                ccmd_last(ccmd)->fwd.fwd_port = fwd_addr.sin_port;
+                ccmd_last(ccmd)->fwd.fwd_host = fwd_addr.sin_addr.s_addr;
+            }
             // TODO: customize forward pkt size
 
             multi_fwds++;
@@ -874,6 +902,12 @@ static error_t argp_client_parse_opt(int key, char *arg, struct argp_state *stat
                     check((dev_id >= 0), "Device id in dev= needs to be a positive integer");
 
                 } else if (strncmp(tok, "sendfile", 8) == 0) {
+#ifdef DPDK_ENABLED
+                    if (proto == DPDK) {
+                        fprintf(stderr, "Error: sendfile is not supported with DPDK\n");
+                        exit(1);
+                    }
+#endif
                     reply_mode = REPLY_MODE_SENDFILE;
 
                 } else {
@@ -979,9 +1013,17 @@ static error_t argp_client_parse_opt(int key, char *arg, struct argp_state *stat
     case SSL_VERIFY:
         arguments->ssl_verify = 1;
         break;
+    case DPDK_TX_CPU:
+        arguments->dpdk_tx_cpu = atoi(arg);
+        break;
+    case DPDK_RX_CPU:
+        arguments->dpdk_rx_cpu = atoi(arg);
+        break;
     case ARGP_KEY_END: // post-parsing validity checks
-        addr_parse(arguments->clienthostport, &myaddr);
-        addr_parse(arguments->nodehostport, &serveraddr);
+        if (proto != DPDK) { // skip host and port parsing for DPDK
+            addr_parse(arguments->clienthostport, &myaddr);
+            addr_parse(arguments->nodehostport, &serveraddr);
+        }
 
         if (send_rate_pd.prob != FIXED && ramp_step_secs == 0) {
             ccmd_destroy(&ccmd);
@@ -1090,7 +1132,62 @@ int main(int argc, char *argv[]) {
     conn_init();
     req_init();
 
+    input_args.dpdk_tx_cpu = -1;
+    input_args.dpdk_rx_cpu = -1;
+
     argp_parse(&argp, argc, argv, ARGP_NO_HELP, 0, &input_args);
+
+#ifdef DPDK_ENABLED
+    if (proto == DPDK) {
+        const char *spec = input_args.clienthostport;
+        int is_pci = (strlen(spec) >= 10 && spec[4] == ':' && spec[7] == ':');
+
+        // build core list
+        int dpdk_core_list[2];
+        int dpdk_num_cores = 0;
+        dpdk_core_list[dpdk_num_cores++] = input_args.dpdk_rx_cpu >= 0
+            ? input_args.dpdk_rx_cpu : 0;
+        if (input_args.dpdk_tx_cpu >= 0 &&
+            input_args.dpdk_tx_cpu != dpdk_core_list[0])
+            dpdk_core_list[dpdk_num_cores++] = input_args.dpdk_tx_cpu;
+
+        dpdk_config_t config = {
+            .iface = is_pci ? NULL : spec,
+            .pci = is_pci ? spec : NULL,
+            .core_list = dpdk_core_list,
+            .num_cores = dpdk_num_cores,
+            .num_queues = 1,
+        };
+        check(dpdk_init(&config) >= 0, "dpdk_init() failed");
+
+        // we store the lcore_id to launch the sender thread on it
+        if (dpdk_num_cores > 1) {
+            unsigned lcore_id;
+            RTE_LCORE_FOREACH_WORKER(lcore_id) {
+                dpdk_tx_lcore = lcore_id;
+                break;
+            }
+        }
+
+        use_dpdk = 1;
+        use_wait_spinning = 1;
+        input_args.num_sessions = 1;
+        pkts_per_session = num_pkts;
+
+        // Destination MAC address parsing
+        unsigned int mac[6];
+        int n = sscanf(input_args.nodehostport, "%x:%x:%x:%x:%x:%x",
+                       &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
+        check(n == 6, "Invalid MAC address: %s", input_args.nodehostport);
+        for (int i = 0; i < 6; i++)
+            dpdk_dest_mac[i] = (uint8_t)mac[i];
+    }
+#else
+    if (proto == DPDK) {
+        fprintf(stderr, "Error: DPDK requested but binary compiled without USE_DPDK=1\n");
+        exit(EXIT_FAILURE);
+    }
+#endif
 
     // If --to ssl://..., then proto == TLS. Setup the SSL context accordingly:
     if (proto == TLS) {
@@ -1219,6 +1316,12 @@ int main(int argc, char *argv[]) {
         SSL_CTX_free(client_ssl_ctx);
         client_ssl_ctx = NULL;
     }
+
+#ifdef DPDK_ENABLED
+    if (use_dpdk) {
+        dpdk_cleanup();
+    }
+#endif
 
     return 0;
 }

--- a/src/dw_client.c
+++ b/src/dw_client.c
@@ -30,6 +30,7 @@
 #ifdef DPDK_ENABLED
 #include "dw_dpdk.h"
 #include "thread_affinity.h"
+#include <rte_ethdev.h>
 #include <rte_lcore.h>
 #include <rte_launch.h>
 static unsigned dpdk_tx_lcore = RTE_MAX_LCORE;
@@ -161,6 +162,34 @@ int try_connect(int* conn_sock, struct sockaddr_in target) {
     return connect(*conn_sock, (struct sockaddr *)&target, sizeof(target));
 }
 
+// Process a received reply message. Returns: 1 = success, -1 = error, -2 = timeout
+int process_reply(message_t *m, int thread_id) {
+    unsigned pkt_id = m->req_id;
+    if (m->status != SUCCESS) {
+        dw_log("REPLY reported an error - %s\n", msg_status_str(m->status));
+        return m->status == ERR ? -1 : -2;
+    }
+    struct timespec ts_now;
+    clock_gettime(clk_id, &ts_now);
+    unsigned long usecs = use_nano
+        ? (ts_now.tv_sec - ts_start.tv_sec) * 1000000000L + (ts_now.tv_nsec - ts_start.tv_nsec)
+        : (ts_now.tv_sec - ts_start.tv_sec) * 1000000 + (ts_now.tv_nsec - ts_start.tv_nsec) / 1000;
+    usecs_elapsed[thread_id][idx(pkt_id)] =
+        usecs - usecs_send[thread_id][idx(pkt_id)];
+    dw_log("thread_id: %d sess_id: %ld req_id %u elapsed %ld us\n", thread_id, pkt_id / pkts_per_session, pkt_id,
+           usecs_elapsed[thread_id][idx(pkt_id)]);
+    return 1;
+}
+
+void *thread_sender(void *data);
+
+#ifdef DPDK_ENABLED
+static int thread_sender_lcore(void *arg) {
+    thread_sender(arg);
+    return 0;
+}
+#endif
+
 void *thread_sender(void *data) {
     thread_data_t *p = (thread_data_t *)data;
 
@@ -186,7 +215,6 @@ void *thread_sender(void *data) {
 
     for (int i = 0; i < num_send_pkts; i++) {
         int pkt_id = first_pkt_id + i;
-        m = conn_prepare_send_message(conn);
 
         // remember time of send relative to ts_start
         struct timespec ts_send;
@@ -195,6 +223,26 @@ void *thread_sender(void *data) {
         usecs_send[thread_id][idx(pkt_id)] = use_nano ? ts_sub_ns(ts_send, ts_start) : ts_sub_us(ts_send, ts_start);
         usecs_elapsed[thread_id][idx(pkt_id)] = 0; // mark corresponding elapsed value as 0, i.e., non-valid 
                                                    // (in case we don't receive all packets back)
+
+#ifdef DPDK_ENABLED
+        if (use_dpdk) {
+            struct rte_mbuf *tx = dpdk_alloc_tx_mbuf(dpdk_dest_mac);
+            if (tx == NULL) {
+                fprintf(stderr, "dpdk_alloc_tx_mbuf() failed at pkt %d\n", pkt_id);
+                break;
+            }
+            m = dpdk_get_payload_ptr(tx);
+            m->req_id = pkt_id;
+            m->req_size = pd_sample(&send_pkt_size_pd);
+            m->status = SUCCESS;
+            ccmd_dump(ccmd, m);
+            dpdk_set_payload_len(tx, m->req_size);
+            if (rte_eth_tx_burst(dpdk_get_port(), 0, &tx, 1) == 0)
+                rte_pktmbuf_free(tx);
+            goto next_pkt;
+        }
+#endif
+        m = conn_prepare_send_message(conn);
 
         // Issue a request to the server
         m->req_id = pkt_id;
@@ -214,7 +262,7 @@ void *thread_sender(void *data) {
         #ifdef DW_DEBUG
             msg_log(m, "Sending msg: ");
         #endif
-        
+
         if (!conn_start_send(conn, conn->target)) {
             fprintf(stderr,
                     "Forcing premature termination of sender thread while "
@@ -295,7 +343,16 @@ void *thread_receiver(void *data) {
             struct timespec ts1, ts2;
             if (conn_times)
                 clock_gettime(CLOCK_MONOTONIC, &ts1);
-            
+
+#ifdef DPDK_ENABLED
+            if (use_dpdk) {
+                struct sockaddr_in dummy = {0};
+                thr_data.conn_id = conn_alloc(-1, dummy, DPDK);
+                check(thr_data.conn_id != -1, "conn_alloc() failed for DPDK");
+                conn_set_status_by_id(thr_data.conn_id, READY);
+                goto spawn_sender;
+            }
+#endif
             // Try to connect client socket to the server
             dw_log("Connecting to %s:%d (sess_id=%d) ...\n", inet_ntoa((struct in_addr) {serveraddr.sin_addr.s_addr}), ntohs(serveraddr.sin_port), (int) (pkt_i / pkts_per_session));
             int rv = 0;
@@ -372,13 +429,47 @@ void *thread_receiver(void *data) {
             } else
                 conn_set_status_by_id(thr_data.conn_id, READY);
 
+#ifdef DPDK_ENABLED
+        spawn_sender:
+#endif
             thr_data.first_pkt_id = pkt_i;
             dw_log("Spawning sender thread for sess_id=%d, first_pkt_id=%d\n", pkt_i / (int)pkts_per_session, pkt_i);
-            sys_check(pthread_create(&sender[thread_id], NULL, thread_sender,
-                                  (void *)&thr_data));
+#ifdef DPDK_ENABLED
+            if (use_dpdk && dpdk_tx_lcore != RTE_MAX_LCORE) {
+                rte_eal_remote_launch(thread_sender_lcore, (void *)&thr_data, dpdk_tx_lcore);
+            } else
+#endif
+            {
+                sys_check(pthread_create(&sender[thread_id], NULL, thread_sender,
+                                      (void *)&thr_data));
+            }
         }
 
         /*---- Read the message from the server into the buffer ----*/
+#ifdef DPDK_ENABLED
+        if (use_dpdk) {
+            conn_info_t *dpdk_conn = conn_get_by_id(thr_data.conn_id);
+            uint16_t nb_rx;
+            int got_dw = 0;
+            while (!got_dw) {
+                while ((nb_rx = rte_eth_rx_burst(dpdk_get_port(), 0, dpdk_conn->rx_mbufs, RX_BURST_SIZE)) == 0);
+                for (uint16_t i = 0; i < nb_rx; i++) {
+                    if (!dpdk_is_dw_packet(dpdk_conn->rx_mbufs[i])) {
+                        rte_pktmbuf_free(dpdk_conn->rx_mbufs[i]);
+                        continue;
+                    }
+                    got_dw = 1;
+                    m = dpdk_get_payload_ptr(dpdk_conn->rx_mbufs[i]);
+                    int rv = process_reply(m, thread_id);
+                    if (rv == 1) { num_success++; i_incr = 1; }
+                    else if (rv == -1) { num_error++; i_incr = 1; }
+                    else { num_timedout++; i_incr = 1; }
+                    rte_pktmbuf_free(dpdk_conn->rx_mbufs[i]);
+                }
+            }
+            goto skip;
+        }
+#endif
         // TODO: support receive of variable reply-size requests
         conn_info_t *conn = conn_get_by_id(thr_data.conn_id);
 
@@ -417,33 +508,10 @@ void *thread_receiver(void *data) {
             msg_log(m, "received message: ");
 #endif
 
-            unsigned pkt_id = m->req_id;
-            if (m->status != SUCCESS) {
-                dw_log("REPLY reported an error - %s\n", msg_status_str(m->status));
-
-                if (m->status == ERR)
-                    num_error++;
-                else
-                    num_timedout++;
-                i_incr = 1;
-            } else {
-                struct timespec ts_now;
-                clock_gettime(clk_id, &ts_now);
-                unsigned long usecs = use_nano
-                    ? (ts_now.tv_sec - ts_start.tv_sec) * 1000000000L + (ts_now.tv_nsec - ts_start.tv_nsec)
-                    : (ts_now.tv_sec - ts_start.tv_sec) * 1000000 + (ts_now.tv_nsec - ts_start.tv_nsec) / 1000;
-                usecs_elapsed[thread_id][idx(pkt_id)] =
-                    usecs - usecs_send[thread_id][idx(pkt_id)];
-                dw_log("thread_id: %d sess_id: %ld req_id %u elapsed %ld us\n", thread_id, pkt_id / pkts_per_session, pkt_id,
-                       usecs_elapsed[thread_id][idx(pkt_id)]);
-
-                num_success++;
-                i_incr = 1;
-
-                #ifdef DW_DEBUG
-                    msg_log(m, "received message: ");
-                #endif
-            }
+            int rv = process_reply(m, thread_id);
+            if (rv == 1) { num_success++; i_incr = 1; }
+            else if (rv == -1) { num_error++; i_incr = 1; }
+            else { num_timedout++; i_incr = 1; }
         }
 
     skip:
@@ -474,9 +542,17 @@ void *thread_receiver(void *data) {
             }
             if (thr_data.conn_id != -1) {
                 dw_log("Joining sender thread\n");
-                pthread_join(sender[thread_id], NULL);
+#ifdef DPDK_ENABLED
+                if (use_dpdk && dpdk_tx_lcore != RTE_MAX_LCORE)
+                    rte_eal_wait_lcore(dpdk_tx_lcore);
+                else
+#endif
+                    pthread_join(sender[thread_id], NULL);
 
-                close(clientSocket[thread_id]);
+#ifdef DPDK_ENABLED
+                if (!use_dpdk)
+#endif
+                    close(clientSocket[thread_id]);
                 conn_free(thr_data.conn_id);
                 thr_data.conn_id = -1;
             }

--- a/src/dw_dpdk.c
+++ b/src/dw_dpdk.c
@@ -1,0 +1,191 @@
+#include "dw_dpdk.h"
+
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+
+#include <rte_eal.h>
+#include <rte_ethdev.h>
+#include <rte_mbuf.h>
+#include <rte_ether.h>
+
+#define MBUF_POOL_NAME      "MBUF_POOL"
+#define NUM_MBUFS           8191        // 2^n - 1 (per queue)
+#define MBUF_CACHE_SIZE     250
+#define MBUF_PRIV_SIZE      0
+#define RX_RING_SIZE        1024
+#define TX_RING_SIZE        1024
+#define DW_ETHERTYPE        0x88B5      // IEEE Local Experimental Ethertype 1
+
+static int num_queues = 1;
+
+static struct rte_mempool *mbuf_pool = NULL;
+static uint16_t dpdk_port = 0;
+static struct rte_ether_addr port_local_mac;
+
+static int port_init(uint16_t port_id, struct rte_ether_addr *out_mac) {
+    int ret;
+    struct rte_eth_conf port_conf = {0};
+    uint16_t nb_rxd = RX_RING_SIZE, nb_txd = TX_RING_SIZE;
+
+    if (!rte_eth_dev_is_valid_port(port_id))
+        return -1;
+
+    ret = rte_eth_dev_configure(port_id, num_queues, num_queues, &port_conf);
+    if (ret != 0) {
+        fprintf(stderr, "[DPDK] Cannot configure port %u\n", port_id);
+        return ret;
+    }
+
+    ret = rte_eth_dev_adjust_nb_rx_tx_desc(port_id, &nb_rxd, &nb_txd);
+    if (ret != 0) {
+        fprintf(stderr, "[DPDK] Cannot adjust descriptors for port %u\n", port_id);
+        return ret;
+    }
+
+    for (int q = 0; q < num_queues; q++) {
+        ret = rte_eth_rx_queue_setup(port_id, q, nb_rxd,
+                                      rte_eth_dev_socket_id(port_id), NULL, mbuf_pool);
+        if (ret < 0) {
+            fprintf(stderr, "[DPDK] Cannot setup RX queue %d for port %u\n", q, port_id);
+            return ret;
+        }
+    }
+
+    for (int q = 0; q < num_queues; q++) {
+        ret = rte_eth_tx_queue_setup(port_id, q, nb_txd,
+                                      rte_eth_dev_socket_id(port_id), NULL);
+        if (ret < 0) {
+            fprintf(stderr, "[DPDK] Cannot setup TX queue %d for port %u\n", q, port_id);
+            return ret;
+        }
+    }
+
+    ret = rte_eth_dev_start(port_id);
+    if (ret < 0) {
+        fprintf(stderr, "[DPDK] Cannot start port %u: %s\n", port_id, rte_strerror(-ret));
+        return -1;
+    }
+
+    ret = rte_eth_macaddr_get(port_id, out_mac);
+    if (ret < 0) {
+        fprintf(stderr, "[DPDK] Cannot get MAC for port %u: %s\n", port_id, rte_strerror(-ret));
+        rte_eth_dev_stop(port_id);
+        return -1;
+    }
+
+    return 0;
+}
+
+int dpdk_init(const dpdk_config_t *config) {
+    int ret;
+
+    if (!config) {
+        fprintf(stderr, "[DPDK] Invalid config\n");
+        return -1;
+    }
+
+    if (!config->iface && !config->pci) {
+        fprintf(stderr, "[DPDK] Need either iface or pci\n");
+        return -1;
+    }
+
+    num_queues = config->num_queues > 0 ? config->num_queues : 1;
+
+    int eal_argc = 0;
+    char *eal_args[20];
+    char fp_arg[64];
+    char dev_arg[256];
+    char lcore_arg[256];
+    char mem_arg[16];
+
+    // build lcore list string from core_list
+    int off = 0;
+    for (int i = 0; i < config->num_cores; i++) {
+        if (i > 0)
+            lcore_arg[off++] = ',';
+        off += snprintf(lcore_arg + off, sizeof(lcore_arg) - off, "%d", config->core_list[i]);
+    }
+    if (off == 0)
+        snprintf(lcore_arg, sizeof(lcore_arg), "0");
+
+    eal_args[eal_argc++] = "dw";
+    eal_args[eal_argc++] = "-l";
+    eal_args[eal_argc++] = lcore_arg;
+    snprintf(fp_arg, sizeof(fp_arg), "--file-prefix=dw_%d", getpid());
+    eal_args[eal_argc++] = fp_arg;
+
+    if (config->pci) {
+        eal_args[eal_argc++] = "-a";
+        eal_args[eal_argc++] = (char*)config->pci;
+        printf("[DPDK] PCI mode: %s\n", config->pci);
+    } else {
+        eal_args[eal_argc++] = "--no-pci";
+        eal_args[eal_argc++] = "--no-huge";
+        // num_nbufs * mbuf_size = 8191 * ~2.3KB ~ 19MB (+ mempool overhead)
+        int mem_mb = 64 * num_queues;
+        snprintf(mem_arg, sizeof(mem_arg), "%d", mem_mb);
+        eal_args[eal_argc++] = "-m";
+        eal_args[eal_argc++] = mem_arg;
+        snprintf(dev_arg, sizeof(dev_arg),
+                 "--vdev=net_af_packet0,iface=%s,qpairs=%d,qdisc_bypass=1",
+                 config->iface, num_queues);
+        eal_args[eal_argc++] = dev_arg;
+        printf("[DPDK] af_packet mode: %s\n", config->iface);
+    }
+
+    eal_args[eal_argc] = NULL;
+
+    ret = rte_eal_init(eal_argc, eal_args);
+    if (ret < 0) {
+        fprintf(stderr, "[DPDK] Error with EAL initialization\n");
+        return -1;
+    }
+
+    uint16_t nb_ports = rte_eth_dev_count_avail();
+    if (nb_ports < 1) {
+        fprintf(stderr, "[DPDK] Need at least 1 port, found %u\n", nb_ports);
+        rte_eal_cleanup();
+        return -1;
+    }
+
+    mbuf_pool = rte_pktmbuf_pool_create(
+        MBUF_POOL_NAME,
+        NUM_MBUFS * num_queues,
+        MBUF_CACHE_SIZE,
+        MBUF_PRIV_SIZE,
+        RTE_MBUF_DEFAULT_BUF_SIZE,
+        rte_socket_id()
+    );
+    if (mbuf_pool == NULL) {
+        fprintf(stderr, "[DPDK] Cannot create mbuf pool (count=%d): %s\n",
+                NUM_MBUFS * num_queues, rte_strerror(rte_errno));
+        rte_eal_cleanup();
+        return -1;
+    }
+
+    dpdk_port = 0; // each distwalk entity owns 1 port
+    if (port_init(dpdk_port, &port_local_mac) < 0) {
+        rte_eal_cleanup();
+        return -1;
+    }
+
+    char mac_str[18];
+    snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x",
+             port_local_mac.addr_bytes[0], port_local_mac.addr_bytes[1],
+             port_local_mac.addr_bytes[2], port_local_mac.addr_bytes[3],
+             port_local_mac.addr_bytes[4], port_local_mac.addr_bytes[5]);
+
+    printf("[DPDK] Ready: %s (MAC: %s)\n",
+           config->pci ? config->pci : config->iface, mac_str);
+
+    return 0;
+}
+
+void dpdk_cleanup(void) {
+    rte_eth_dev_stop(dpdk_port);
+    rte_eth_dev_close(dpdk_port);
+    rte_eal_cleanup();
+    mbuf_pool = NULL;
+}

--- a/src/dw_dpdk.c
+++ b/src/dw_dpdk.c
@@ -189,3 +189,51 @@ void dpdk_cleanup(void) {
     rte_eal_cleanup();
     mbuf_pool = NULL;
 }
+
+uint16_t dpdk_get_port(void) {
+    return dpdk_port;
+}
+
+void *dpdk_get_payload_ptr(struct rte_mbuf *m) {
+    return rte_pktmbuf_mtod_offset(m, void *, sizeof(struct rte_ether_hdr));
+}
+
+void dpdk_set_payload_len(struct rte_mbuf *m, size_t len) {
+    m->data_len = sizeof(struct rte_ether_hdr) + len;
+    m->pkt_len = sizeof(struct rte_ether_hdr) + len;
+}
+
+void dpdk_extract_src_mac(struct rte_mbuf *m, uint8_t *mac) {
+    struct rte_ether_hdr *eth = rte_pktmbuf_mtod(m, struct rte_ether_hdr *);
+    memcpy(mac, eth->src_addr.addr_bytes, 6);
+}
+
+struct rte_mbuf *dpdk_alloc_tx_mbuf(const uint8_t *dest_mac) {
+    struct rte_mbuf *m = rte_pktmbuf_alloc(mbuf_pool);
+    if (m == NULL)
+        return NULL;
+
+    struct rte_ether_hdr *eth = rte_pktmbuf_mtod(m, struct rte_ether_hdr *);
+    memcpy(eth->dst_addr.addr_bytes, dest_mac, 6);
+    rte_ether_addr_copy(&port_local_mac, &eth->src_addr);
+    eth->ether_type = rte_cpu_to_be_16(DW_ETHERTYPE);
+
+    m->data_len = sizeof(struct rte_ether_hdr);
+    m->pkt_len = sizeof(struct rte_ether_hdr);
+
+    return m;
+}
+
+int dpdk_is_dw_packet(struct rte_mbuf *m) {
+    struct rte_ether_hdr *eth = rte_pktmbuf_mtod(m, struct rte_ether_hdr *);
+    return rte_be_to_cpu_16(eth->ether_type) == DW_ETHERTYPE;
+}
+
+void dpdk_flush_tx(struct rte_mbuf **mbufs, uint16_t *count, uint16_t queue_id) {
+    if (*count > 0) {
+        uint16_t nb_tx = rte_eth_tx_burst(dpdk_port, queue_id, mbufs, *count);
+        for (uint16_t j = nb_tx; j < *count; j++)
+            rte_pktmbuf_free(mbufs[j]);
+        *count = 0;
+    }
+}

--- a/src/dw_dpdk.c
+++ b/src/dw_dpdk.c
@@ -9,6 +9,7 @@
 #include <rte_ethdev.h>
 #include <rte_mbuf.h>
 #include <rte_ether.h>
+#include <rte_pmd_i40e.h>
 
 #define MBUF_POOL_NAME      "MBUF_POOL"
 #define NUM_MBUFS           8191        // 2^n - 1 (per queue)
@@ -31,6 +32,16 @@ static int port_init(uint16_t port_id, struct rte_ether_addr *out_mac) {
 
     if (!rte_eth_dev_is_valid_port(port_id))
         return -1;
+
+    if (num_queues > 1) {
+        struct rte_eth_dev_info dev_info;
+        ret = rte_eth_dev_info_get(port_id, &dev_info);
+        if (ret != 0)
+            return ret;
+        port_conf.rxmode.mq_mode = RTE_ETH_MQ_RX_RSS;
+        port_conf.rx_adv_conf.rss_conf.rss_hf =
+            RTE_ETH_RSS_L2_PAYLOAD & dev_info.flow_type_rss_offloads;
+    }
 
     ret = rte_eth_dev_configure(port_id, num_queues, num_queues, &port_conf);
     if (ret != 0) {
@@ -66,6 +77,21 @@ static int port_init(uint16_t port_id, struct rte_ether_addr *out_mac) {
     if (ret < 0) {
         fprintf(stderr, "[DPDK] Cannot start port %u: %s\n", port_id, rte_strerror(-ret));
         return -1;
+    }
+
+    // RSS configuration to hash on source MAC for L2 payload (i40e PF only)
+    if (num_queues > 1) {
+        struct rte_pmd_i40e_inset inset = { .inset = 0 };
+        rte_pmd_i40e_inset_field_set(&inset.inset, 3); // SMAC bytes 0-1
+        rte_pmd_i40e_inset_field_set(&inset.inset, 4); // SMAC bytes 2-3
+        rte_pmd_i40e_inset_field_set(&inset.inset, 5); // SMAC bytes 4-5
+        ret = rte_pmd_i40e_inset_set(port_id, 63, &inset, INSET_HASH);
+        if (ret == 0) {
+            printf("[DPDK] RSS input set: source MAC on L2_PAYLOAD (i40e)\n");
+        } else {
+            fprintf(stderr, "[DPDK] WARNING: RSS on source MAC not available, "
+                    "all packets will go to a single queue\n");
+        }
     }
 
     ret = rte_eth_macaddr_get(port_id, out_mac);

--- a/src/dw_dpdk.h
+++ b/src/dw_dpdk.h
@@ -6,6 +6,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <rte_mbuf.h>
 
 typedef struct {
     const char *iface;         // af_packet interface (e.g., "veth0")
@@ -17,5 +18,16 @@ typedef struct {
 
 int dpdk_init(const dpdk_config_t *config);
 void dpdk_cleanup(void);
+uint16_t dpdk_get_port(void);
+
+void *dpdk_get_payload_ptr(struct rte_mbuf *mbuf);
+void dpdk_set_payload_len(struct rte_mbuf *mbuf, size_t len);
+void dpdk_extract_src_mac(struct rte_mbuf *mbuf, uint8_t *mac);
+
+struct rte_mbuf *dpdk_alloc_tx_mbuf(const uint8_t *dest_mac);
+
+int dpdk_is_dw_packet(struct rte_mbuf *mbuf);
+
+void dpdk_flush_tx(struct rte_mbuf **mbufs, uint16_t *count, uint16_t queue_id);
 
 #endif

--- a/src/dw_dpdk.h
+++ b/src/dw_dpdk.h
@@ -1,0 +1,21 @@
+#ifndef __DW_DPDK_H__
+#define __DW_DPDK_H__
+
+#define RX_BURST_SIZE 32
+#define TX_BURST_SIZE 32
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+    const char *iface;         // af_packet interface (e.g., "veth0")
+    const char *pci;           // PCI address (e.g., "0000:04:02.0"), alternative to iface
+    int *core_list;            // array of core IDs for EAL lcore list
+    int num_cores;             // length of core_list
+    int num_queues;            // number of RX/TX queue pairs (node: 1 per worker, client: always 1)
+} dpdk_config_t;
+
+int dpdk_init(const dpdk_config_t *config);
+void dpdk_cleanup(void);
+
+#endif

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -315,7 +315,9 @@ int remove_timeout(conn_worker_info_t* infos, int req_id, dw_poll_t *p_poll) {
 
 void setnonblocking(int fd);
 
-int find_forward_reply_id(command_t *cmd, struct sockaddr_in from_addr);
+// match_addr is 6 bytes: either fwd_host(4)+fwd_port(2) or fwd_addr[6],
+// same union in fwd_opts_t, so memcmp on fwd_addr covers both cases
+int find_forward_reply_id(command_t *cmd, const uint8_t match_addr[6]);
 
 // cmd_id is the index of the FORWARD item within m->cmds[] here, we
 // remove the first (cmd_id+1) commands from cmds[], and forward the
@@ -331,7 +333,7 @@ command_t *single_start_forward(req_info_t *req, message_t *m, command_t *cmd, d
     addr.sin_addr.s_addr = fwd.fwd_host;
     addr.sin_port = fwd.fwd_port;
 
-    int fwd_reply_id = find_forward_reply_id(req->curr_cmd, addr);
+    int fwd_reply_id = find_forward_reply_id(req->curr_cmd, fwd.fwd_addr);
     if (fwd_reply_id == -1)
         return NULL;
 
@@ -473,18 +475,19 @@ int process_messages(req_info_t *req, dw_poll_t *p_poll, conn_worker_info_t* inf
 int obtain_messages(int conn_id, dw_poll_t *p_poll, conn_worker_info_t* infos);
 
 // return 0-based id if found, or -1 if not found
-int find_forward_reply_id(command_t *cmd, struct sockaddr_in from_addr) {
+// match_addr is 6 bytes: either fwd_host(4)+fwd_port(2) or fwd_addr[6],
+// same union in fwd_opts_t, so memcmp on fwd_addr covers both cases
+int find_forward_reply_id(command_t *cmd, const uint8_t match_addr[6]) {
     int id = 0;
     for (; cmd != NULL; cmd = cmd_next_forward(cmd), id++) {
-        if (cmd_get_opts(fwd_opts_t, cmd)->fwd_host == from_addr.sin_addr.s_addr
-            && cmd_get_opts(fwd_opts_t, cmd)->fwd_port == from_addr.sin_port)
+        if (memcmp(cmd_get_opts(fwd_opts_t, cmd)->fwd_addr, match_addr, 6) == 0)
             return id;
     }
     return -1;
 }
 
-// Call this once we received a REPLY from a socket matching a req_id we forwarded
-int handle_forward_reply(int req_id, dw_poll_t *p_poll, conn_worker_info_t* infos, msg_status_t fwd_m_status, struct sockaddr_in from_addr) {
+// Call this once we received a REPLY from a connection matching a req_id we forwarded
+int handle_forward_reply(int req_id, dw_poll_t *p_poll, conn_worker_info_t* infos, msg_status_t fwd_m_status, const uint8_t match_addr[6], proto_t proto) {
     req_info_t *req = req_get_by_id(req_id);
 
     if (!req) {
@@ -492,12 +495,24 @@ int handle_forward_reply(int req_id, dw_poll_t *p_poll, conn_worker_info_t* info
         return -1;
     }
 
-    int reply_id = find_forward_reply_id(req->curr_cmd, from_addr);
-    dw_log("Found reply_id %d from: %s:%d (conn_id: %d)\n", reply_id,
-           inet_ntoa((struct in_addr) {from_addr.sin_addr.s_addr}), ntohs(from_addr.sin_port), req->conn_id);
+    // human readable string that supports both cases
+    char addr_str[64];
+    if (proto == DPDK) {
+        snprintf(addr_str, sizeof(addr_str), "%02x:%02x:%02x:%02x:%02x:%02x",
+                 match_addr[0], match_addr[1], match_addr[2],
+                 match_addr[3], match_addr[4], match_addr[5]);
+    } else {
+        struct in_addr addr;
+        uint16_t port;
+        memcpy(&addr, match_addr, 4);
+        memcpy(&port, match_addr + 4, 2);
+        snprintf(addr_str, sizeof(addr_str), "%s:%d", inet_ntoa(addr), ntohs(port));
+    }
+
+    int reply_id = find_forward_reply_id(req->curr_cmd, match_addr);
+    dw_log("Found reply_id %d from: %s (conn_id: %d)\n", reply_id, addr_str, req->conn_id);
     if (reply_id == -1) {
-        dw_log("Got a REPLY to FORWARD from an unexpected endpoint: %s:%d - Dropped",
-               inet_ntoa((struct in_addr) {from_addr.sin_addr.s_addr}), ntohs(from_addr.sin_port));
+        dw_log("Got a REPLY to FORWARD from an unexpected endpoint: %s - Dropped\n", addr_str);
         return -1;
     }
     
@@ -814,7 +829,10 @@ int obtain_messages(int conn_id, dw_poll_t *p_poll, conn_worker_info_t* infos) {
         if (message_first_cmd(m)->cmd == EOM) {
             dw_log("Handling response to FORWARD from %s:%d, req_id=%d\n", inet_ntoa((struct in_addr) {conns[conn_id].target.sin_addr.s_addr}), 
                                                                            ntohs(conns[conn_id].target.sin_port), m->req_id);
-            if (!handle_forward_reply(m->req_id, p_poll, infos, m->status, conns[conn_id].target)) {
+            uint8_t fwd_match[6];
+            memcpy(fwd_match, &conn->target.sin_addr.s_addr, 4);
+            memcpy(fwd_match + 4, &conn->target.sin_port, 2);
+            if (!handle_forward_reply(m->req_id, p_poll, infos, m->status, fwd_match, conn->proto)) {
                     dw_log("handle_forward_reply() failed\n");
                     return 0;
             }

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -37,6 +37,11 @@
 #include "address_utils.h"
 #include "dw_poll.h"
 
+#ifdef DPDK_ENABLED
+#include "dw_dpdk.h"
+static int use_dpdk = 0;
+#endif
+
 #define MAX_EVENTS 10
 
 volatile uint8_t running = 1;
@@ -1419,7 +1424,7 @@ struct argp_node_arguments {
 
 static struct argp_option argp_node_options[] = {
     // long name, short name, value name, flag, description
-    {"bind-addr",         BIND_ADDR,        "[tcp|udp|ssl:[//]][host][:port]",0,  "DistWalk node bindname, bindport, and communication protocol (can be specified multiple times)"},
+    {"bind-addr",         BIND_ADDR,        "[tcp|udp|ssl:[//]][host][:port] | dpdk://[iface|pci]",0,  "DistWalk node bind address, and communication protocol (can be specified multiple times)"},
     {"accept-mode",       ACCEPT_MODE,      "child|shared|parent",            0,  "Accept mode (per-worker thread, shared or parent-only listening queue)"},
     {"poll-mode",         POLL_MODE,        "epoll|poll|select",              0,  "Poll mode (defaults to epoll)"},
     {"backlog-length",    BACKLOG_LENGTH,   "n",                              0,  "Maximum pending connections queue length"},
@@ -1803,6 +1808,44 @@ int main(int argc, char *argv[]) {
         core_it = aff_it_init(&mask, nproc);
     }
 
+#ifdef DPDK_ENABLED
+    for (int i = 0; i < n_bind_addrs; i++) {
+        if (bind_addrs[i].protocol == DPDK) {
+            const char *spec = bind_addrs[i].nodehostport;
+            int is_pci = (strlen(spec) >= 10 && spec[4] == ':' && spec[7] == ':');
+
+            // build the core list
+            int dpdk_core_list[MAX_THREADS];
+            if (input_args.use_thread_affinity) {
+                int it = aff_it_init(&mask, nproc);
+                for (int c = 0; c < input_args.num_threads; c++) {
+                    dpdk_core_list[c] = it;
+                    aff_it_next(&it, &mask, nproc);
+                }
+            } else {
+                // no affinity mask, use cores 0..num_threads-1
+                for (int c = 0; c < input_args.num_threads; c++)
+                    dpdk_core_list[c] = c;
+            }
+
+            dpdk_config_t config = {
+                .iface = is_pci ? NULL : spec,
+                .pci = is_pci ? spec : NULL,
+                .core_list = dpdk_core_list,
+                .num_cores = input_args.num_threads,
+                .num_queues = input_args.num_threads,
+            };
+            if (dpdk_init(&config) < 0) {
+                fprintf(stderr, "dpdk_init() failed\n");
+                exit(EXIT_FAILURE);
+            }
+            use_dpdk = 1;
+            use_wait_spinning = 1;
+            break;
+        }
+    }
+#endif
+
     conn_init();
     req_init();
 
@@ -2005,6 +2048,15 @@ int main(int argc, char *argv[]) {
 
     // For each requested bind-addr, init the listen socket(s)
     for (int l = 0; l < n_bind_addrs; l++) {
+#ifdef DPDK_ENABLED
+        if (bind_addrs[l].protocol == DPDK)
+            continue;
+#else
+        if (bind_addrs[l].protocol == DPDK) {
+            fprintf(stderr, "Error: DPDK requested but binary compiled without USE_DPDK=1\n");
+            exit(EXIT_FAILURE);
+        }
+#endif
         addr_parse(bind_addrs[l].nodehostport, &serverAddr);
         for (int i = 0; i < conn_threads; i++) {
             init_listen_sock(i, accept_mode, bind_addrs[l].protocol, serverAddr);
@@ -2087,6 +2139,12 @@ int main(int argc, char *argv[]) {
         SSL_CTX_free(server_ssl_ctx);
         server_ssl_ctx = NULL;
     }
+
+#ifdef DPDK_ENABLED
+    if (use_dpdk) {
+        dpdk_cleanup();
+    }
+#endif
 
     return 0;
 }

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -39,6 +39,7 @@
 
 #ifdef DPDK_ENABLED
 #include "dw_dpdk.h"
+#include <rte_ethdev.h>
 static int use_dpdk = 0;
 #endif
 
@@ -132,6 +133,10 @@ typedef struct {
     // load-balancing stats
     atomic_int active_conns;
     atomic_int active_reqs;
+
+#ifdef DPDK_ENABLED
+    uint16_t queue_id;
+#endif
 } conn_worker_info_t;
 
 typedef struct {
@@ -347,6 +352,47 @@ command_t *single_start_forward(req_info_t *req, message_t *m, command_t *cmd, d
             cmd_log(cmd);
         return cmd == NULL ? cmd_skip(req->curr_cmd, 1) : cmd;
     }
+#ifdef DPDK_ENABLED
+    if (fwd.proto == DPDK) {
+        conn_info_t *my_conn = conn_get_by_id(req->conn_id);
+        if (my_conn->tx_count >= TX_BURST_SIZE)
+            dpdk_flush_tx(my_conn->tx_mbufs, &my_conn->tx_count, infos->queue_id);
+
+        struct rte_mbuf *tx_mbuf = dpdk_alloc_tx_mbuf(fwd.fwd_addr);
+        if (tx_mbuf == NULL) {
+            fprintf(stderr, "dpdk_alloc_tx_mbuf() failed for forward\n");
+            return NULL;
+        }
+
+        message_t *m_dst = dpdk_get_payload_ptr(tx_mbuf);
+        m_dst->req_size = fwd.pkt_size;
+
+        // skip possible FORWARD_CONTINUE cmds in non-branched multi-fwd
+        command_t *c = cmd_next(cmd);
+        while (c->cmd == FORWARD_CONTINUE)
+            c = cmd_next(c);
+
+        command_t *reply_cmd = message_copy_tail(m, m_dst, c);
+        if (!reply_cmd) {
+            dw_log("message_copy_tail(): destination message out-of-space\n");
+            rte_pktmbuf_free(tx_mbuf);
+            return NULL;
+        }
+
+        m_dst->req_id = req->req_id;
+        m_dst->req_size = fwd.pkt_size;
+        m_dst->status = SUCCESS;
+
+        dpdk_set_payload_len(tx_mbuf, fwd.pkt_size);
+        my_conn->tx_mbufs[my_conn->tx_count++] = tx_mbuf;
+
+        dw_log("Forwarding req %u via DPDK\n", m_dst->req_id);
+
+        if (req->fwd_timeout)
+            insert_timeout(infos, req->req_id, p_poll, req->fwd_timeout);
+        return cmd;
+    }
+#endif
     int fwd_conn_id = conn_find_existing(addr, fwd.proto);
     conn_info_t *fwd_conn;
     if (fwd_conn_id == -1) {
@@ -542,8 +588,36 @@ int handle_forward_reply(int req_id, dw_poll_t *p_poll, conn_worker_info_t* info
 
 // returns 1 if reply sent correctly, 0 otherwise
 int reply(req_info_t *req, message_t *m, command_t *cmd, conn_worker_info_t* infos) {
-    message_t *m_dst = conn_prepare_send_message(&conns[req->conn_id]);
+    conn_info_t *conn = conn_get_by_id(req->conn_id);
     reply_opts_t *opts = cmd_get_opts(reply_opts_t, cmd);
+
+#ifdef DPDK_ENABLED
+    if (conn->proto == DPDK) {
+        if (conn->tx_count >= TX_BURST_SIZE)
+            dpdk_flush_tx(conn->tx_mbufs, &conn->tx_count, infos->queue_id);
+
+        struct rte_mbuf *tx_mbuf = dpdk_alloc_tx_mbuf(req->reply_mac);
+        if (tx_mbuf == NULL) {
+            fprintf(stderr, "dpdk_alloc_tx_mbuf() failed\n");
+            return 0;
+        }
+
+        message_t *m_dst = dpdk_get_payload_ptr(tx_mbuf);
+        m_dst->req_id = m->req_id;
+        m_dst->req_size = opts->resp_size;
+        m_dst->cmds[0].cmd = EOM;
+        m_dst->status = m->status;
+        dpdk_set_payload_len(tx_mbuf, opts->resp_size);
+
+        conn->tx_mbufs[conn->tx_count++] = tx_mbuf;
+
+        conn_req_remove(conn, req);
+        infos->active_reqs--;
+        return 1;
+    }
+#endif
+
+    message_t *m_dst = conn_prepare_send_message(conn);
     assert(m_dst->req_size >= opts->resp_size);
 
 
@@ -556,8 +630,6 @@ int reply(req_info_t *req, message_t *m, command_t *cmd, conn_worker_info_t* inf
 #ifdef DW_DEBUG
     msg_log(m_dst, "REPLY ");
 #endif
-
-    conn_info_t *conn = conn_get_by_id(req->conn_id);
     // cannot access req after conn_req_remove()
     int conn_id = req->conn_id;
     struct sockaddr_in target = req->target;
@@ -1210,6 +1282,16 @@ void* conn_worker(void* args) {
 
     sys_check(sched_setattr(0, &infos->sched_attrs, 0));
 
+#ifdef DPDK_ENABLED
+    if (use_dpdk) {
+        struct sockaddr_in dummy = {0};
+        int dpdk_conn_id = conn_alloc(-1, dummy, DPDK);
+        check(dpdk_conn_id != -1, "conn_alloc() failed for DPDK worker %d", infos->worker_id);
+        conn_set_status_by_id(dpdk_conn_id, READY);
+        conn_get_by_id(dpdk_conn_id)->enable_defrag = enable_defrag;
+    }
+#endif
+
     if (accept_mode != AM_PARENT || infos == &conn_worker_infos[0]) {
         for (int i = 0; i < infos->n_listen_socks; i++) {
             int s = infos->listen_socks[i];
@@ -1256,6 +1338,63 @@ void* conn_worker(void* args) {
                 exit(EXIT_FAILURE);
             }
         }
+
+#ifdef DPDK_ENABLED
+        if (use_dpdk) {
+            struct sockaddr_in dummy = {0};
+            int my_dpdk_conn_id = conn_find_existing(dummy, DPDK);
+            conn_info_t *conn = conn_get_by_id(my_dpdk_conn_id);
+
+            uint16_t nb_rx = rte_eth_rx_burst(dpdk_get_port(), infos->queue_id, conn->rx_mbufs, RX_BURST_SIZE);
+
+
+            for (uint16_t i = 0; i < nb_rx; i++) {
+                struct rte_mbuf *m = conn->rx_mbufs[i];
+
+                if (!dpdk_is_dw_packet(m)) {
+                    rte_pktmbuf_free(m);
+                    continue;
+                }
+
+                uint8_t src_mac[6];
+                dpdk_extract_src_mac(m, src_mac);
+
+                message_t *msg = dpdk_get_payload_ptr(m);
+
+                if (message_first_cmd(msg)->cmd == EOM) {
+                    if (!handle_forward_reply(msg->req_id, &infos->dw_poll, infos, msg->status, src_mac, DPDK))
+                        dw_log("handle_forward_reply() failed for DPDK\n");
+                } else {
+                    req_info_t *req = conn_req_add(conn);
+                    if (req == NULL) {
+                        fprintf(stderr, "conn_req_add() failed for DPDK\n");
+                        rte_pktmbuf_free(m);
+                        continue;
+                    }
+                    memcpy(req->reply_mac, src_mac, 6);
+                    infos->active_reqs++;
+
+                    req->message_ptr = (unsigned char *)msg;
+                    req->curr_cmd = message_first_cmd(msg);
+
+                    int executed = process_single_message(req, &infos->dw_poll, infos);
+
+                    if (executed == 0) {
+                        int cmd_offset = (unsigned char *)req->curr_cmd - (unsigned char *)msg;
+                        memcpy(conn->curr_recv_buf, msg, msg->req_size);
+                        req->message_ptr = conn->curr_recv_buf;
+                        req->curr_cmd = (command_t *)(conn->curr_recv_buf + cmd_offset);
+                        conn->curr_recv_buf += msg->req_size;
+                        conn->curr_recv_size -= msg->req_size;
+                    }
+                }
+
+                rte_pktmbuf_free(m);
+            }
+
+            dpdk_flush_tx(conn->tx_mbufs, &conn->tx_count, infos->queue_id);
+        }
+#endif
 
         uint64_t aux;
         dw_poll_flags pflags;
@@ -2040,6 +2179,12 @@ int main(int argc, char *argv[]) {
 
         conn_worker_infos[i].active_conns = 0;
         conn_worker_infos[i].active_reqs = 0;
+
+#ifdef DPDK_ENABLED
+        if (use_dpdk) {
+            conn_worker_infos[i].queue_id = i;
+        }
+#endif
 
         // Auxiliary communication medium
         if (accept_mode == AM_PARENT) {

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -40,6 +40,8 @@
 #ifdef DPDK_ENABLED
 #include "dw_dpdk.h"
 #include <rte_ethdev.h>
+#include <rte_lcore.h>
+#include <rte_launch.h>
 static int use_dpdk = 0;
 #endif
 
@@ -1269,15 +1271,29 @@ void* storage_worker(void* args) {
     return (void*)1;
 }
 
+void* conn_worker(void* args);
+
+#ifdef DPDK_ENABLED
+static int conn_worker_lcore(void *arg) {
+    conn_worker(arg);
+    return 0;
+}
+#endif
+
 void* conn_worker(void* args) {
     conn_worker_info_t *infos = (conn_worker_info_t *)args;
 
     sprintf(thread_name, "connw-%d", infos->worker_id);
     sys_check(prctl(PR_SET_NAME, thread_name, NULL, NULL, NULL));
 
-    if (infos->core_id >= 0) {
-        sys_check(aff_pin_to(infos->core_id));
-        dw_log("thread %ld pinned to core %i\n", pthread_self(), infos->core_id);
+#ifdef DPDK_ENABLED
+    if (!use_dpdk)
+#endif
+    {
+        if (infos->core_id >= 0) {
+            sys_check(aff_pin_to(infos->core_id));
+            dw_log("thread %ld pinned to core %i\n", pthread_self(), infos->core_id);
+        }
     }
 
     sys_check(sched_setattr(0, &infos->sched_attrs, 0));
@@ -2242,6 +2258,22 @@ int main(int argc, char *argv[]) {
     }
 
     // Run
+#ifdef DPDK_ENABLED
+    if (use_dpdk) {
+        // launch workers 1..N-1 on remote lcores
+        unsigned lcore_id;
+        int w = 1;
+        RTE_LCORE_FOREACH_WORKER(lcore_id) {
+            if (w >= input_args.num_threads)
+                break;
+            rte_eal_remote_launch(conn_worker_lcore, &conn_worker_infos[w], lcore_id);
+            w++;
+        }
+        // worker 0 runs on the main lcore (the current one)
+        conn_worker((void *)&conn_worker_infos[0]);
+        rte_eal_mp_wait_lcore(); // wait until all lcores terminate
+    } else
+#endif
     if (input_args.num_threads == 1) {
         conn_worker((void*) &conn_worker_infos[0]);
     } else {

--- a/src/message.c
+++ b/src/message.c
@@ -15,6 +15,7 @@ inline const char *proto_str(proto_t proto) {
         "UDP",
         "TCP",
         "SSL",
+        "DPDK",
     };
     return proto_str[proto];
 }

--- a/src/message.h
+++ b/src/message.h
@@ -12,14 +12,19 @@
 
 typedef enum { COMPUTE, STORE, LOAD, PSKIP, FORWARD_BEGIN, FORWARD_CONTINUE, REPLY, EOM } command_type_t;
 
-typedef enum { UDP, TCP, TLS, PROTO_NUMBER } proto_t;
+typedef enum { UDP, TCP, TLS, DPDK, PROTO_NUMBER } proto_t;
 
 typedef enum { SUCCESS, TIMEOUT, ERR, MSG_STATUS_NUMBER } msg_status_t;
 
 typedef struct {
     uint32_t pkt_size;    // size of forwarded packet
-    in_addr_t fwd_host;   // target IP of host to forward to (network encoding)
-    uint16_t fwd_port;    // target port (network encoding, for multiple nodes on same host)
+    union {
+        struct {
+            in_addr_t fwd_host;   // target IP of host to forward to (network encoding)
+            uint16_t fwd_port;    // target port (network encoding, for multiple nodes on same host)
+        };
+        uint8_t fwd_addr[6];       // target MAC address (for DPDK)
+    };
     uint32_t timeout;     // timeout in microsecond (0 means no timeout)
     uint8_t retries;      // how many times to reply before failing
     uint8_t n_ack;        // forward-reply concern (number of acknowledgments)

--- a/src/request.h
+++ b/src/request.h
@@ -23,6 +23,7 @@ struct req_info_t {
     unsigned char *message_ptr;
     command_t *curr_cmd;
     node_t *timeout_node;
+    uint8_t reply_mac[6];
     req_info_t *prev, *next;
 
     // --- Added for sendfile() support ---

--- a/test/dpdk_common.sh
+++ b/test/dpdk_common.sh
@@ -1,0 +1,83 @@
+DPDK_MODE="${DPDK_MODE:-}"
+DPDK_IFACE=()
+DPDK_MAC=()
+
+
+dpdk_check_root() {
+    if [ $(id -u) -ne 0 ]; then
+        echo "DPDK tests require root privileges, run with sudo"
+        exit 77
+    fi
+}
+
+dpdk_check_binary() {
+     if ! ldd ../src/dw_node_debug 2>/dev/null | grep -q "librte"; then
+        echo "DPDK tests require USE_DPDK=1 build"
+        exit 77
+    fi
+}
+
+dpdk_find_pf() {
+    for iface in /sys/class/net/*; do
+        # /sys/class/net/*/device/driver is a link to /sys/bus/pci/drivers/driver/<iface_driver>
+        local driver=$(basename "$(readlink -f $iface/device/driver 2>/dev/null)" 2>/dev/null)
+        local name=$(basename $iface)
+
+        # check if the driver is DPDK compatible
+        case "$driver" in i40e|ice|ixgbe|mlx5_core)
+            local pci=$(basename "$(readlink -f $iface/device)")
+            local totalvfs=$(cat /sys/bus/pci/devices/$pci/sriov_totalvfs 2>/dev/null)
+
+            # check if the PF supports SRIOV virtualization
+            if [ -n "$totalvfs" ] && [ "$totalvfs" -gt 0 ]; then
+                local state=$(cat /sys/class/net/$name/operstate 2>/dev/null)
+
+                # making sure the PF is down
+                if [ "$state" != "up" ]; then
+                    echo "$pci $name"
+                    return 0
+                fi
+            fi
+        ;;esac
+    done
+    return 1
+}
+
+dpdk_auto_setup() {
+    local n=${1:-4}
+    local output
+
+    if [ "$DPDK_MODE" = "vf" ]; then
+        pf_info=$(dpdk_find_pf) || { echo "No DPDK-compatible PF found"; exit 77; }
+    elif [ "$DPDK_MODE" != "veth" ]; then
+        pf_info=$(dpdk_find_pf) && DPDK_MODE="vf" || DPDK_MODE="veth"
+    fi
+
+    if [ "$DPDK_MODE" = "vf" ]; then
+        local pf_pci=$(echo "$pf_info" | cut -d' ' -f1)
+        local pf_iface=$(echo "$pf_info" | cut -d' ' -f2)
+        echo "Using VF backend: $pf_iface ($pf_pci), creating $n VFs"
+        output=$(bash dpdk_vf_setup.sh "$n" "$pf_pci" "$pf_iface")
+    else
+        DPDK_MODE="veth"
+        echo "Using veth backend ($n pairs)"
+        output=$(bash dpdk_veth_setup.sh "$n")
+    fi
+
+    local i=0
+    while read -r iface mac; do
+        DPDK_IFACE[$i]="$iface"
+        DPDK_MAC[$i]="$mac"
+        i=$((i + 1))
+    done <<< "$output"
+
+}
+
+dpdk_auto_teardown() {
+    kill_all SIGKILL 2>/dev/null || true
+    if [ "$DPDK_MODE" = "vf" ]; then
+        bash dpdk_vf_destroy.sh
+    elif [ "$DPDK_MODE" = "veth" ]; then
+        bash dpdk_veth_destroy.sh
+    fi
+}

--- a/test/dpdk_veth_destroy.sh
+++ b/test/dpdk_veth_destroy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Destroys the specified number of veths and the bridge
+N=${1:-4}
+BRIDGE=dw_br
+
+for i in $(seq 0 $((N - 1))); do
+    ip link del dw_veth${i} 2>/dev/null || true
+done
+
+ip link del $BRIDGE 2>/dev/null || true

--- a/test/dpdk_veth_setup.sh
+++ b/test/dpdk_veth_setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Sets up an amount of veths specified by the (optional) parameter N and interconnects them via a bridge
+
+set -e
+
+N=${1:-4}
+BRIDGE=dw_br
+
+ip link add $BRIDGE type bridge
+ip link set $BRIDGE up
+
+for i in $(seq 0 $((N - 1))); do
+    ip link add dw_veth${i} type veth peer name dw_veth${i}_br
+    ip link set dw_veth${i} up
+    ip link set dw_veth${i}_br up
+    ip link set dw_veth${i}_br master $BRIDGE
+done
+
+sleep 2
+
+for i in $(seq 0 $((N - 1))); do
+    echo "dw_veth${i} $(cat /sys/class/net/dw_veth${i}/address)"
+done

--- a/test/dpdk_vf_destroy.sh
+++ b/test/dpdk_vf_destroy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Deletes the previously created VFs
+
+PF_PCI=${1:-0000:04:00.0}
+
+cur_vfs=$(cat /sys/bus/pci/devices/$PF_PCI/sriov_numvfs 2>/dev/null || echo 0)
+for i in $(seq 0 $((cur_vfs - 1))); do
+    vf_pci=$(basename "$(readlink /sys/bus/pci/devices/$PF_PCI/virtfn$i 2>/dev/null)" 2>/dev/null)
+    [ -n "$vf_pci" ] && dpdk-devbind.py -u "$vf_pci" 2>/dev/null || true
+done
+
+echo 0 > /sys/bus/pci/devices/$PF_PCI/sriov_numvfs 2>/dev/null || true

--- a/test/dpdk_vf_setup.sh
+++ b/test/dpdk_vf_setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Creates the specified amount of VFs from a single PF
+set -e
+
+N=$1
+PF_PCI=${2:-0000:04:00.0}
+PF_IFACE=${3:-enp4s0f0np0}
+
+echo $N > /sys/bus/pci/devices/$PF_PCI/sriov_numvfs
+sleep 3
+
+for i in $(seq 0 $((N - 1))); do
+    vf_pci=$(basename "$(readlink /sys/bus/pci/devices/$PF_PCI/virtfn$i)")
+    vf_iface=$(ls /sys/bus/pci/devices/$vf_pci/net/)
+    mac=$(cat /sys/class/net/$vf_iface/address)
+    dpdk-devbind.py -b vfio-pci $vf_pci
+    echo "$vf_pci $mac"
+done

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -2,6 +2,7 @@
 
 COL_RED='\033[0;32m'
 COL_GRN='\e[0;31m'
+COL_YLW='\e[0;33m'
 COL_DEF='\e[m'
 
 rm -rf *.gcda *.gcov log_tests.txt gcov/ ../src/*.gcda ../src/gcov/
@@ -16,13 +17,29 @@ else
     TESTS=( $(find ../src/ -name 'test_*' -executable | grep -v '~$') $(ls test_*.sh) )
 fi
 
-for test in "${TESTS[@]}"; do
-    echo -n "TEST $test: "
-    echo -e "\n\nTEST $test:\n" >> log_tests.txt
-    if bash -c ./$test >> log_tests.txt 2>&1; then
+run_test() {
+    local test=$1
+    local label=$2
+    echo -n "TEST $label: "
+    echo -e "\n\nTEST $label:\n" >> log_tests.txt
+    bash -c ./$test >> log_tests.txt 2>&1
+    rc=$?
+    if [ $rc -eq 0 ]; then
         echo -e "${COL_RED}SUCCESS${COL_DEF}"
+    elif [ $rc -eq 77 ]; then
+        echo -e "${COL_YLW}SKIPPED${COL_DEF} (non-root or missing USE_DPDK)"
     else
         echo -e "${COL_GRN}ERROR${COL_DEF}"
+    fi
+}
+
+for test in "${TESTS[@]}"; do
+    if [[ "$test" == *dpdk* ]]; then
+        for mode in veth vf; do
+            DPDK_MODE=$mode run_test "$test" "$test (dpdk=$mode)"
+        done
+    else
+        run_test "$test" "$test"
     fi
 done
 

--- a/test/test_dpdk.sh
+++ b/test/test_dpdk.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+. common.sh
+. dpdk_common.sh
+
+dpdk_check_root
+dpdk_check_binary
+dpdk_auto_setup 2
+trap dpdk_auto_teardown EXIT
+
+NODE_OPT="-b dpdk://${DPDK_IFACE[0]} -c 0"
+CLIENT_OPT="-b dpdk://${DPDK_IFACE[1]} --to dpdk://${DPDK_MAC[0]} --dpdk-rx-cpu 1 --dpdk-tx-cpu 2"
+
+TMP_CLIENT=$(mktemp /tmp/dw-dpdk-client-XXX.txt)
+
+run dw_node_debug $NODE_OPT &> /dev/null &
+sleep 2
+
+echo "--- basic compute ---"
+run dw_client_debug $CLIENT_OPT -n 100 -C 0 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 100" $TMP_CLIENT
+
+run dw_client_debug $CLIENT_OPT -n 100 -C 10 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 100" $TMP_CLIENT
+
+run dw_client_debug $CLIENT_OPT -n 100 -C 100 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 100" $TMP_CLIENT
+
+echo "--- compute with payload ---"
+run dw_client_debug $CLIENT_OPT -n 50 -C 100 -p 25 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 50" $TMP_CLIENT
+
+run dw_client_debug $CLIENT_OPT -n 50 -C 100 -p 50 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 50" $TMP_CLIENT
+
+run dw_client_debug $CLIENT_OPT -n 100 -C 100 -p 100 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 100" $TMP_CLIENT
+
+echo "--- random distributions ---"
+run dw_client_debug $CLIENT_OPT -n 50 -C unif:min=50,max=200 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 50" $TMP_CLIENT
+
+run dw_client_debug $CLIENT_OPT -n 50 -C exp:100 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 50" $TMP_CLIENT
+
+run dw_client_debug $CLIENT_OPT -n 50 -C norm:100,std=20 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 50" $TMP_CLIENT
+
+echo "--- mixed distributions ---"
+run dw_client_debug $CLIENT_OPT -n 50 -C unif:min=15,max=20 -p 18 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 50" $TMP_CLIENT
+
+run dw_client_debug $CLIENT_OPT -n 50 -C exp:100 -p unif:min=10,max=15 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 50" $TMP_CLIENT
+
+rm -f $TMP_CLIENT
+kill_all

--- a/test/test_dpdk_async.sh
+++ b/test/test_dpdk_async.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Test async DPDK operations: store, load, and DPDK-to-DPDK forward chains
+
+. common.sh
+. dpdk_common.sh
+
+dpdk_check_root
+dpdk_check_binary
+dpdk_auto_setup 4
+trap dpdk_auto_teardown EXIT
+
+NODE1_OPT="-b dpdk://${DPDK_IFACE[0]} -c 0"
+NODE2_OPT="-b dpdk://${DPDK_IFACE[2]} -c 3"
+NODE3_OPT="-b dpdk://${DPDK_IFACE[3]} -c 4"
+CLIENT_OPT="-b dpdk://${DPDK_IFACE[1]} --to dpdk://${DPDK_MAC[0]} --dpdk-rx-cpu 1 --dpdk-tx-cpu 2"
+
+TMP_STORE=$(mktemp /tmp/dw-dpdk-store-XXX.txt)
+TMP_CLIENT=$(mktemp /tmp/dw-dpdk-client-XXX.txt)
+
+echo "--- store/load over DPDK ---"
+
+run dw_node_debug $NODE1_OPT -s $TMP_STORE &> /dev/null &
+sleep 2
+
+run dw_client_debug $CLIENT_OPT -n 1 -S 32768 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 1" $TMP_CLIENT
+
+run dw_client_debug $CLIENT_OPT -n 1 -L 1024 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 1" $TMP_CLIENT
+
+run dw_client_debug $CLIENT_OPT -n 1 -S 4096 -L 1024 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 1" $TMP_CLIENT
+
+kill_all SIGKILL
+sleep 1
+
+echo "--- simple forward: DPDK -> DPDK ---"
+
+run dw_node_debug $NODE1_OPT &> /dev/null &
+run dw_node_debug $NODE2_OPT &> /dev/null &
+sleep 2
+
+run dw_client_debug $CLIENT_OPT -n 10 -F dpdk://${DPDK_MAC[2]} -C 100 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 10" $TMP_CLIENT
+
+kill_all SIGINT
+sleep 1
+
+echo "--- nested, multi-forward and branched ---"
+
+run dw_node_debug $NODE1_OPT &> /dev/null &
+run dw_node_debug $NODE2_OPT &> /dev/null &
+run dw_node_debug $NODE3_OPT &> /dev/null &
+sleep 2
+
+# nested: client -> node1 -> node2 -> node3
+run dw_client_debug $CLIENT_OPT -n 10 -F dpdk://${DPDK_MAC[2]} -F dpdk://${DPDK_MAC[3]} -C 100 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 10" $TMP_CLIENT
+
+# multi-forward: client -> node1 -> node2 AND node3
+run dw_client_debug $CLIENT_OPT -n 10 -F dpdk://${DPDK_MAC[2]},dpdk://${DPDK_MAC[3]} -C 100 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 10" $TMP_CLIENT
+
+# nack=1 (wait for fastest only)
+run dw_client_debug $CLIENT_OPT -n 10 -F dpdk://${DPDK_MAC[2]},dpdk://${DPDK_MAC[3]},nack=1 -C 100 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 10" $TMP_CLIENT
+
+# branched multi-forward
+run dw_client_debug $CLIENT_OPT -n 10 -F dpdk://${DPDK_MAC[2]},branch -C 100 -F dpdk://${DPDK_MAC[3]},branch -C 200 -R -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 10" $TMP_CLIENT
+
+kill_all SIGINT
+sleep 1
+
+rm -f $TMP_STORE $TMP_CLIENT
+kill_all

--- a/test/test_dpdk_hybrid.sh
+++ b/test/test_dpdk_hybrid.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Hybrid test: client -> node1 (DPDK) -> node2/node3 (TCP and/or DPDK)
+
+. common.sh
+. dpdk_common.sh
+
+dpdk_check_root
+dpdk_check_binary
+dpdk_auto_setup 3
+trap dpdk_auto_teardown EXIT
+
+NODE1_OPT="-b dpdk://${DPDK_IFACE[0]} -c 0"
+CLIENT_OPT="-b dpdk://${DPDK_IFACE[1]} --to dpdk://${DPDK_MAC[0]} --dpdk-rx-cpu 1 --dpdk-tx-cpu 2"
+
+TMP_CLIENT=$(mktemp /tmp/dw-dpdk-client-XXX.txt)
+
+echo "--- forward: DPDK -> TCP ---"
+
+run dw_node_debug $NODE1_OPT &> /dev/null &
+run dw_node_debug -b :7892 &> /dev/null &
+sleep 2
+
+# forward: client -DPDK-> node1 -TCP-> node2
+run dw_client_debug $CLIENT_OPT -n 50 -F localhost:7892 -C 100 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 50" $TMP_CLIENT
+
+# pre-compute on node1, forward to node2, post-compute on node1
+run dw_client_debug $CLIENT_OPT -n 50 -C 50 -F localhost:7892 -C 100 -R -C 50 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 50" $TMP_CLIENT
+
+echo "--- nested forward: DPDK -> TCP -> TCP ---"
+
+# nested: client -DPDK-> node1 -TCP-> node2 -TCP-> node3
+run dw_node_debug -b :7893 &> /dev/null &
+sleep 1
+run dw_client_debug $CLIENT_OPT -n 20 -F localhost:7892 -F localhost:7893 -C 100 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 20" $TMP_CLIENT
+
+echo "--- multi-forward: DPDK + TCP ---"
+
+# multi-forward: node1 forwards to node2 (DPDK) and node3 (TCP)
+kill_all
+sleep 1
+
+run dw_node_debug $NODE1_OPT &> /dev/null &
+run dw_node_debug -b dpdk://${DPDK_IFACE[2]} -c 3 &> /dev/null &
+run dw_node_debug -b :7893 &> /dev/null &
+sleep 2
+
+run dw_client_debug $CLIENT_OPT -n 20 -C 0 -F dpdk://${DPDK_MAC[2]},localhost:7893 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 20" $TMP_CLIENT
+
+run dw_client_debug $CLIENT_OPT -n 20 -C 0 -F dpdk://${DPDK_MAC[2]},localhost:7893,nack=1 -p 1000 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 20" $TMP_CLIENT
+
+rm -f $TMP_CLIENT
+kill_all

--- a/test/test_dpdk_stress.sh
+++ b/test/test_dpdk_stress.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Stress test: high packet counts, high send rates, multiple DPDK clients
+
+. common.sh
+. dpdk_common.sh
+
+dpdk_check_root
+dpdk_check_binary
+dpdk_auto_setup 3
+trap dpdk_auto_teardown EXIT
+
+NODE_OPT="-b dpdk://${DPDK_IFACE[0]} -c 0"
+CLIENT1_OPT="-b dpdk://${DPDK_IFACE[1]} --to dpdk://${DPDK_MAC[0]} --dpdk-rx-cpu 1 --dpdk-tx-cpu 2"
+CLIENT2_OPT="-b dpdk://${DPDK_IFACE[2]} --to dpdk://${DPDK_MAC[0]} --dpdk-rx-cpu 3 --dpdk-tx-cpu 4"
+
+TMP_CLIENT=$(mktemp /tmp/dw-dpdk-client-XXX.txt)
+
+echo "--- high send rate ---"
+
+run dw_node_debug $NODE_OPT &> /dev/null &
+sleep 2
+
+run dw_client_debug $CLIENT1_OPT -n 500 -C 0 -p 2 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 500" $TMP_CLIENT
+
+kill_all SIGINT
+sleep 1
+
+echo "--- large packet sizes ---"
+
+run dw_node_debug $NODE_OPT &> /dev/null &
+sleep 2
+
+run dw_client_debug $CLIENT1_OPT -n 100 -C 0 --ps=1400 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 100" $TMP_CLIENT
+
+run dw_client_debug $CLIENT1_OPT -n 100 -C 0 --rs=1400 > $TMP_CLIENT
+cat $TMP_CLIENT
+grep -q "success: 100" $TMP_CLIENT
+
+kill_all SIGINT
+sleep 1
+
+echo "--- two clients simultaneously ---"
+
+run dw_node_debug $NODE_OPT &> /dev/null &
+sleep 2
+
+TMP_C1=$(mktemp /tmp/dw-dpdk-client1-XXX.txt)
+TMP_C2=$(mktemp /tmp/dw-dpdk-client2-XXX.txt)
+run dw_client_debug $CLIENT1_OPT -n 500 -C 0 -p 10 > $TMP_C1 &
+pid1=$!
+run dw_client_debug $CLIENT2_OPT -n 500 -C 0 -p 10 > $TMP_C2 &
+pid2=$!
+wait $pid1 $pid2
+
+cat $TMP_C1
+grep -q "success: 500" $TMP_C1
+
+cat $TMP_C2
+grep -q "success: 500" $TMP_C2
+
+kill_all SIGINT
+sleep 1
+
+rm -f $TMP_CLIENT $TMP_C1 $TMP_C2
+kill_all


### PR DESCRIPTION
 Adds a DPDK data path to DistWalk, addressing #7. Built with `make USE_DPDK=1` and enabled at run time by binding to a DPDK-compatible interface via `dpdk://<iface|PCI>` on both nodes and clients.
 
 The DPDK path coexists with the socket-based one. A single node can be used to serve both DPDK and sockets. 

  ## Key points

  - Layer 2, raw Ethernet frames, one mbuf per DistWalk message.
  - `fwd_opt_t` union unifies the handling of MAC addresses and IPv4 + Port
  - `conn_workers` and client 's sender/receiver threads run as lcore DPDK threads, pinned on CPU cores that can be specified with CLI options                    
  - Support for multi-threading is done via RSS on source MAC (Intel i40e).                                                    
  - Scripts to automatically setup veth and SR-IOV VFs, plus tests