### PR TITLE
dw_client: remove unused argument from pd_build_none() call

### DIFF
--- a/src/dw_client.c
+++ b/src/dw_client.c
@@ -993,7 +993,7 @@ static error_t argp_client_parse_opt(int key, char *arg, struct argp_state *stat
 
             } while (arg != NULL && *arg != '\0');
         } else {
-            val = pd_build_none(default_resp_size);
+            val = pd_build_none();
         }
 
         if (pd_is_none(&val)) {


### PR DESCRIPTION
The function signature was changed to take no arguments, but line 996 was still passing default_resp_size, causing a compilation error. Remove the unused argument to match the function signature. The default value is still applied later via pd_build_fixed() if needed.