### PR TITLE
dw_node: improve thread names for better debuggability

### DIFF
--- a/src/dw_client.c
+++ b/src/dw_client.c
@@ -193,7 +193,7 @@ static int thread_sender_lcore(void *arg) {
 void *thread_sender(void *data) {
     thread_data_t *p = (thread_data_t *)data;
 
-    sprintf(thread_name, "sendw-%d", p->thread_id);
+    sprintf(thread_name, "dwc_send_%d", p->thread_id);
     sys_check(prctl(PR_SET_NAME, thread_name, NULL, NULL, NULL));
 
     int thread_id = p->thread_id;
@@ -315,7 +315,7 @@ void *thread_sender(void *data) {
 void *thread_receiver(void *data) {
     const int thread_id = (int)(unsigned long)data;
 
-    sprintf(thread_name, "recvw-%d", thread_id);
+    sprintf(thread_name, "dwc_recv_%d", thread_id);
     sys_check(prctl(PR_SET_NAME, thread_name, NULL, NULL, NULL));
     message_t *m = NULL;
     int recv = 0;

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -1136,7 +1136,7 @@ void* storage_worker(void* args) {
     storage_worker_info_t *infos = (storage_worker_info_t *)args;
     infos->sync_waiting_queue = pqueue_alloc(MAX_REQS);
 
-    sprintf(thread_name, "storagew-%d", infos->worker_id);
+    sprintf(thread_name, "stor_work-%d", infos->worker_id);
     sys_check(prctl(PR_SET_NAME, thread_name, NULL, NULL, NULL));
 
     if (infos->core_id >= 0) {
@@ -1281,7 +1281,7 @@ static int conn_worker_lcore(void *arg) {
 void* conn_worker(void* args) {
     conn_worker_info_t *infos = (conn_worker_info_t *)args;
 
-    sprintf(thread_name, "connw-%d", infos->worker_id);
+    sprintf(thread_name, "conn_work-%d", infos->worker_id);
     sys_check(prctl(PR_SET_NAME, thread_name, NULL, NULL, NULL));
 
 #ifdef DPDK_ENABLED
@@ -1476,7 +1476,7 @@ void* conn_worker(void* args) {
                     if (dw_poll_add(&conn_worker_infos[next_thread_id].dw_poll, conn_sock, DW_POLLIN, i2l(SOCKET, conn_id)) != 0)
                         perror("dw_poll() failed");
                 }
-                dw_log("conn_id: %d assigned to connw-%d\n", conn_id, next_thread_id);
+                dw_log("conn_id: %d assigned to conn_work%d\n", conn_id, next_thread_id);
             } else if (event_type == STORAGE) {
                 int store_replyfd = event_data;
 

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -1136,7 +1136,7 @@ void* storage_worker(void* args) {
     storage_worker_info_t *infos = (storage_worker_info_t *)args;
     infos->sync_waiting_queue = pqueue_alloc(MAX_REQS);
 
-    sprintf(thread_name, "stor_work-%d", infos->worker_id);
+    sprintf(thread_name, "dwn_stor_%d", infos->worker_id);
     sys_check(prctl(PR_SET_NAME, thread_name, NULL, NULL, NULL));
 
     if (infos->core_id >= 0) {
@@ -1281,7 +1281,7 @@ static int conn_worker_lcore(void *arg) {
 void* conn_worker(void* args) {
     conn_worker_info_t *infos = (conn_worker_info_t *)args;
 
-    sprintf(thread_name, "conn_work-%d", infos->worker_id);
+    sprintf(thread_name, "dwn_conn_%d", infos->worker_id);
     sys_check(prctl(PR_SET_NAME, thread_name, NULL, NULL, NULL));
 
 #ifdef DPDK_ENABLED


### PR DESCRIPTION
Closes #81

Rename worker threads to more descriptive names:
- `connw-%d` → `conn_work-%d`
- `storagew-%d` → `stor_work-%d`

Thread names are now consistent and more readable when inspecting 
the process with htop, top, or gdb.

Tested with ./src/dw_node --nt 10 and verified via:
  cat /proc/<pid>/task/*/comm