### PR TITLE
Fix use-after-free of req in dw_node.c and improve Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 all:
-	cd src && make all
+  	cd src && $(MAKE) all
 
 run-tests: all
-	cd test && ./run-tests.sh
+  	cd test && ./run-tests.sh
 
 cov-scan: clean
 
 clean:
 	rm -f *~ dw_node dw_client dw_node_debug dw_client_debug
-	cd src && make clean
+	cd src && $(MAKE) clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ MAKEFILE_DIR := $(dir $(firstword $(MAKEFILE_LIST)))
 TOPDIR       := $(abspath $(MAKEFILE_DIR)/..)
 
 CFLAGS=-Wall -O3
-CFLAGS_DEBUG=-g -DDW_DEBUG -Wall -fprofile-arcs -ftest-coverage -fprofile-update=atomic
+CFLAGS_DEBUG=-g -DDW_DEBUG -Wall -fprofile-arcs -ftest-coverage -fprofile-update=atomic -fsanitize=address -fsanitize=undefined
 CFLAGS_TSAN=-g -Wall -O2 -fsanitize=thread
 LDLIBS=-pthread -lm -lssl -lcrypto
 LDLIBS_DEBUG=-pthread -lm -lssl -lcrypto -lgcov
@@ -60,10 +60,10 @@ doc:
 	doxygen
 
 clean:
-	rm -rf $(HOME)/.local/share/man/man1/
-	mandb
-	rm -f *.o *.gcno *.gcda *.gcov *~ *.bak log_tests.txt *.log $(MAIN_PROGRAMS) $(DEBUG_PROGRAMS) $(TSAN_PROGRAMS) $(TEST_PROGRAMS)
-	rm -rf html latex gcov $(ifneq $(BUILD_DIR),.,$(BUILD_DIR))
+  rm -rf $(HOME)/.local/share/man/man1/
+  mandb
+  rm -f *.o *.d *.gcno *.gcda *.gcov *~ *.bak log_tests.txt *.log $(MAIN_PROGRAMS) $(DEBUG_PROGRAMS) $(TSAN_PROGRAMS) $(TEST_PROGRAMS)
+  rm -rf html latex gcov $(ifneq $(BUILD_DIR),.,$(BUILD_DIR))
 
 dw_client: $(patsubst %.c,$(BUILD_DIR)/%.o,$(DW_CLIENT_SOURCES))
 dw_client_debug: $(patsubst %.c,$(BUILD_DIR)/%_debug.o,$(DW_CLIENT_SOURCES))

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -635,29 +635,38 @@ int reply(req_info_t *req, message_t *m, command_t *cmd, conn_worker_info_t* inf
 #ifdef DW_DEBUG
     msg_log(m_dst, "REPLY ");
 #endif
+    const int conn_id = req->conn_id;
+    const struct sockaddr_in target = req->target;
+
+    conns[conn_id].reply_mode = opts->mode;
+    int rv;
+
+    // added branching here for the two send-mode cases
+    switch (opts->mode) {
+        case REPLY_MODE_SENDFILE: {
+            // retrieve device id from reply options
+            int dev_id = opts->dev_id; 
+            // note! fd must be copied here since req will be freed after this function returns, 
+            //  but the sendfile operation may not be completed yet  
+            req->sendfile_fd = storage_worker_infos[dev_id].storage_info.storage_fd;
+            req->sendfile_offset = 0;
+            req->sendfile_size = opts->resp_size;
+            printf("Reply using sendfile.\n");
+            rv =  conn_start_sendfile(&conns[conn_id], target, req->sendfile_fd, req->sendfile_offset, req->sendfile_size);
+            break;
+        }
+        case REPLY_MODE_NORMAL:
+        default:{
+            rv = conn_start_send(&conns[conn_id], target); 
+            break;
+        }
+    }
+
     // cannot access req after conn_req_remove()
-    int conn_id = req->conn_id;
-    struct sockaddr_in target = req->target;
     conn_req_remove(conn, req);
     infos->active_reqs--;
 
-    // added branching here for the two cases
-    conns[conn_id].reply_mode = opts->mode;
-
-    switch (opts->mode) {
-
-    case REPLY_MODE_SENDFILE:
-        int dev_id = opts->dev_id; // retrieve device id from reply options
-        req->sendfile_fd = storage_worker_infos[dev_id].storage_info.storage_fd; // note! fd must be copied here since req will be freed after this function returns,but the sendfile operation may not be completed yet
-        req->sendfile_offset = 0;
-        req->sendfile_size = opts->resp_size;
-        printf("Reply using sendfile.\n");
-        return conn_start_sendfile(&conns[conn_id], target, req->sendfile_fd, req->sendfile_offset, req->sendfile_size);
-    
-    case REPLY_MODE_NORMAL:
-    default:
-        return conn_start_send(&conns[conn_id], target); // unchanged 
-    }
+    return rv;
 }
 
 void compute_for_freqinv(unsigned long usecs) {


### PR DESCRIPTION
- in dw_node.c there was a use-after-free on req, which was called after having called conn_req_remove(conn, req).
- Makefile now clears *.d files, and uses -fsanitize=address -fsanitize=undefined