### PR TITLE
dw_node.c : fix use-after-free of req in reply(). Makefile: clean *.d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	cd src && make all
+	cd src && $(MAKE) all
 
 run-tests: all
 	cd test && ./run-tests.sh
@@ -8,4 +8,4 @@ cov-scan: clean
 
 clean:
 	rm -f *~ dw_node dw_client dw_node_debug dw_client_debug
-	cd src && make clean
+	cd src && $(MAKE) clean

--- a/src/Makefile
+++ b/src/Makefile
@@ -62,7 +62,7 @@ doc:
 clean:
 	rm -rf $(HOME)/.local/share/man/man1/
 	mandb
-	rm -f *.o *.gcno *.gcda *.gcov *~ *.bak log_tests.txt *.log $(MAIN_PROGRAMS) $(DEBUG_PROGRAMS) $(TSAN_PROGRAMS) $(TEST_PROGRAMS)
+	rm -f *.o *.d *.gcno *.gcda *.gcov *~ *.bak log_tests.txt *.log $(MAIN_PROGRAMS) $(DEBUG_PROGRAMS) $(TSAN_PROGRAMS) $(TEST_PROGRAMS)
 	rm -rf html latex gcov $(ifneq $(BUILD_DIR),.,$(BUILD_DIR))
 
 dw_client: $(patsubst %.c,$(BUILD_DIR)/%.o,$(DW_CLIENT_SOURCES))

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -635,14 +635,9 @@ int reply(req_info_t *req, message_t *m, command_t *cmd, conn_worker_info_t* inf
 #ifdef DW_DEBUG
     msg_log(m_dst, "REPLY ");
 #endif
-    // cannot access req after conn_req_remove()
-    int conn_id = req->conn_id;
-    struct sockaddr_in target = req->target;
-    conn_req_remove(conn, req);
-    infos->active_reqs--;
-
     // added branching here for the two cases
-    conns[conn_id].reply_mode = opts->mode;
+    conns[req->conn_id].reply_mode = opts->mode;
+    int rv;
 
     switch (opts->mode) {
 
@@ -652,12 +647,18 @@ int reply(req_info_t *req, message_t *m, command_t *cmd, conn_worker_info_t* inf
         req->sendfile_offset = 0;
         req->sendfile_size = opts->resp_size;
         dw_log("Reply using sendfile\n");
-        return conn_start_sendfile(&conns[conn_id], target, req->sendfile_fd, req->sendfile_offset, req->sendfile_size);
+        rv =  conn_start_sendfile(&conns[req->conn_id], req->target, req->sendfile_fd, req->sendfile_offset, req->sendfile_size);
+        break;
     
     case REPLY_MODE_NORMAL:
     default:
-        return conn_start_send(&conns[conn_id], target); // unchanged 
+        rv = conn_start_send(&conns[req->conn_id], req->target);
+        break;
     }
+    // cannot access req after conn_req_remove()
+    conn_req_remove(conn, req);
+    infos->active_reqs--;
+    return rv;
 }
 
 void compute_for_freqinv(unsigned long usecs) {


### PR DESCRIPTION
dw_node.c : fix use-after-free of req in reply(), which was being used after a conn_req_remove(conn, req)
Makefile: clean *.d