### PR TITLE
Added asan and ubsan to debug build and fixed leaks found by tests

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ MAKEFILE_DIR := $(dir $(firstword $(MAKEFILE_LIST)))
 TOPDIR       := $(abspath $(MAKEFILE_DIR)/..)
 
 CFLAGS=-Wall -O3
-CFLAGS_DEBUG=-g -DDW_DEBUG -Wall -fprofile-arcs -ftest-coverage -fprofile-update=atomic
+CFLAGS_DEBUG=-g -DDW_DEBUG -Wall -fprofile-arcs -ftest-coverage -fprofile-update=atomic -fsanitize=address -fsanitize=undefined
 CFLAGS_TSAN=-g -Wall -O2 -fsanitize=thread
 LDLIBS=-pthread -lm -lssl -lcrypto
 LDLIBS_DEBUG=-pthread -lm -lssl -lcrypto -lgcov

--- a/src/distrib.c
+++ b/src/distrib.c
@@ -425,3 +425,7 @@ double pd_avg(pd_spec_t *p) {
     }
     return rv;
 }
+
+void pd_cleanup(const pd_spec_t *p) {
+    if (p->prob == SFILE) free(p->samples);
+}

--- a/src/distrib.h
+++ b/src/distrib.h
@@ -68,4 +68,7 @@ double pd_avg(pd_spec_t *p);
 // might be handy independently from pd_*() functions
 int sscanf_unit(const char *str, const char *fmt, double *p_val, int is_time);
 
+// deallocate memory, if necessary (e.g., p->samples for SFILE)
+void pd_cleanup(const pd_spec_t *p);
+
 #endif

--- a/src/dw_client.c
+++ b/src/dw_client.c
@@ -1212,6 +1212,9 @@ static error_t argp_client_parse_opt(int key, char *arg, struct argp_state *stat
     return 0;
 }
 
+static char** script_parse_argv = NULL;
+static int script_parse_argc = 0;
+
 int script_parse(char *fname, struct argp_state *state) {
     FILE *f = fopen(fname, "r");
     check(f != NULL, "Could not open script file: %s\n", fname);
@@ -1258,8 +1261,18 @@ int script_parse(char *fname, struct argp_state *state) {
         }
     }
 
-    free(argv);
+    script_parse_argv = argv;
+    script_parse_argc = argc;
     return 0;
+}
+
+void script_parse_cleanup() {
+    if (script_parse_argv != NULL) {
+        for (int i=0; i<script_parse_argc; i++) {
+            free(script_parse_argv[i]);
+        }
+        free(script_parse_argv);
+    }
 }
 
 // csv output, there is just the values separated with a separator 
@@ -1536,6 +1549,9 @@ int main(int argc, char *argv[]) {
         fclose(output_fp);
         output_fp = NULL;
     }
+
+    // if the argp_parse read from a file, cleanup the allocated strings
+    script_parse_cleanup();
 
     return 0;
 }

--- a/src/test_distrib.c
+++ b/src/test_distrib.c
@@ -39,5 +39,8 @@ int main(int argc, char **argv) {
     for (int i = 0; i < num_samples; i++)
         printf("%g\n", pd_sample(&val));
 
+    // frees if we loaded from file
+    pd_cleanup(&val);
+
     return EXIT_SUCCESS;
 }

--- a/src/test_queue.c
+++ b/src/test_queue.c
@@ -40,7 +40,7 @@ bool test_queue_insert() {
 bool test_queue_insert_complex() {
 	queue_t *queue = queue_alloc(N);
 
-	ccmd_node_t* ccmd_node = calloc(1, sizeof(ccmd_node_t));
+	ccmd_node_t* ccmd_node = alloca(sizeof(ccmd_node_t));
 	pd_spec_t val = pd_build_fixed(1000);
 
 	ccmd_node->cmd = STORE;
@@ -107,7 +107,7 @@ bool test_queue_remove_complex() {
 	queue_t *queue = queue_alloc(N);
 
 	for (int i=0; i < 2; i ++) {
-		ccmd_node_t* ccmd_node = calloc(1, sizeof(ccmd_node_t));
+		ccmd_node_t* ccmd_node = alloca(sizeof(ccmd_node_t));
 		pd_spec_t val = pd_build_fixed(i * 10);
 
 		ccmd_node->cmd = STORE;

--- a/test/test_sched.sh
+++ b/test/test_sched.sh
@@ -43,6 +43,9 @@ fi
 ! node_bg --sched-policy=dl:10000
 
 if [ "$(whoami)" == "root" ]; then
+    # asan and sched_deadline do not work together
+    export ASAN_OPTIONS=detect_leaks=0
+
     node_bg --sched-policy=dl:10000,20000
     chrt -a -p $(pidof dw_node_debug) | grep -q "current scheduling policy: SCHED_DEADLINE"
     chrt -a -p $(pidof dw_node_debug) | grep -q "current scheduling runtime/deadline/period parameters: 10000000/20000000/20000000"
@@ -52,6 +55,8 @@ if [ "$(whoami)" == "root" ]; then
     [ $(chrt -a -p $(pidof dw_node_debug) | grep -c "current scheduling policy: SCHED_DEADLINE") -eq 2 ]
     [ $(chrt -a -p $(pidof dw_node_debug) | grep -c "current scheduling runtime/deadline/period parameters: 10000000/20000000/20000000") -eq 2 ]
     kill_all SIGINT
+
+    unset ASAN_OPTIONS
 fi
 
 # This is needed when launched as non-root


### PR DESCRIPTION
- dw_client.c did not free arguments when loaded from file
- test_distrib.c leaked distribution parameters when read from file
- test_queue.c did not free the nodes it allocated
- note: test_sched.sh in deadline is not compatible with leak detection and needs to be disabled