### PR TITLE
Added fixes and improvements, e.g. cmd_bounded_next to better resist malformed and malsized messages

### DIFF
--- a/src/ccmd.c
+++ b/src/ccmd.c
@@ -111,7 +111,9 @@ int ccmd_dump(queue_t* q, message_t* m) {
                 fprintf(stderr, "ccmd_dump() - Unknown command type\n");
                 exit(EXIT_FAILURE);
         }
-        m_cmd_itr = cmd_next(m_cmd_itr);
+        m_cmd_itr = cmd_bounded_next(m_cmd_itr, message_end(m));
+        if (!m_cmd_itr)
+            return 0;
         ccmd_itr = ccmd_itr->next;
     }
     if (avail < cmd_type_size(EOM))

--- a/src/connection.c
+++ b/src/connection.c
@@ -180,6 +180,8 @@ int conn_find_existing(struct sockaddr_in target, proto_t proto) {
         }
         if (conns[i].sock == -1)
             continue;
+        if (conns[i].is_listen)
+            continue;
         if (proto == UDP && conns[i].parent_thread == curr_thread) {
             rv = i;
             break;

--- a/src/connection.c
+++ b/src/connection.c
@@ -88,10 +88,12 @@ conn_status_t conn_get_status_by_id(int conn_id) {
 }
 
 conn_info_t* conn_get_by_id(int conn_id) {
+    if (conn_id < 0 || conn_id >= MAX_CONNS) return NULL;
     return &conns[conn_id];
 }
 
 int conn_get_id_by_ptr(conn_info_t * conn) {
+    assert(conn >= &conns[0] && conn <= &conns[MAX_CONNS - 1]);
     return conn - &conns[0];
 }
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -258,7 +258,7 @@ void conn_free(int conn_id) {
         conns[conn_id].ssl = NULL;
     }
 
-    conns[conn_id].status = CLOSE;
+    conns[conn_id].status = CLOSED;
     conns[conn_id].sock = -1;
     atomic_store(&conns[conn_id].busy, 0);
 
@@ -422,7 +422,7 @@ static int conn_ssl_send(conn_info_t *conn) {
         }
         if (err == SSL_ERROR_ZERO_RETURN) {
             dw_log("SSL connection closed by peer\n");
-            conn->status = CLOSE;
+            conn->status = CLOSING;
             pthread_mutex_unlock(&conn->ssl_mtx);
             return 0;
         }
@@ -486,32 +486,44 @@ int conn_send(conn_info_t *conn) {
     ssize_t sent = sendto(sock, conn->curr_send_buf, conn->curr_send_size, MSG_NOSIGNAL, (const struct sockaddr*)&conn->target, sizeof(conn->target));
     if (sent == 0) {
         // TODO: should not even be possible, ignoring
-        dw_log("SEND returned 0\n");
+        dw_log("conn_send: SEND returned 0 (unreachable hopefully)\n");
         return 0;
     }
+    dw_log("conn_send: dw_sendto returned something different from 0 : %ld.\n", sent);
 
     if (sent == -1) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            dw_log("SEND Got EAGAIN or EWOULDBLOCK, ignoring...\n");
-            return 0;
-        } 
+        dw_log("conn_send: dw_sendto returned -1.\n");
 
-        if (errno == EPIPE || errno == ECONNRESET) {
-            dw_log("SEND Connection closed by remote end conn_id=%d\n", conn_get_id_by_ptr(conn));
-            conn->status = CLOSE;
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            // should be unreachable
+            dw_log("conn_send: SEND Got EAGAIN or EWOULDBLOCK, setting conn_status to SENDING\n");
+            conn_set_status(conn, SENDING);
             return 0;
         }
 
-        fprintf(stderr, "SEND Unexpected error: %s\n", strerror(errno));
+        if (errno == EPIPE || errno == ECONNRESET) {
+            dw_log("conn_send: SEND Connection closed by remote end conn_id=%d\n", conn_get_id_by_ptr(conn));
+            conn->status = CLOSING;
+            return 0;
+        }
+
+        fprintf(stderr, "conn_send: SEND Unexpected error: %s\n", strerror(errno));
         return -1;
     }
-    dw_log("SEND returned: %d\n", (int)sent);
+    dw_log("conn_send: SEND returned: %d\n", (int)sent);
 
     conn->curr_send_buf += sent;
     conn->curr_send_size -= sent;
-    if (conn->curr_send_size == 0)
+    if (conn->curr_send_size == 0) {
         conn->curr_send_buf = conn->send_buf;
 
+        // reset status as the buffer is now fully empty
+        if (conn->status == SENDING)
+            conn_set_status(conn, READY);
+        return (int) sent;
+    }
+
+    dw_log("conn_send: returning sent:%ld\n", sent);
     return (int)sent;
 }
 
@@ -528,7 +540,7 @@ int conn_send_v2(conn_info_t *conn) {
         
         if (sent <= 0) {
             if (errno == EAGAIN || errno == EWOULDBLOCK) continue; // try again until we can send the header
-            if (errno == EPIPE || errno == ECONNRESET) { conn->status = CLOSE; return -1; }
+            if (errno == EPIPE || errno == ECONNRESET) { conn->status = CLOSING; return -1; }
         }
 
         conn->curr_send_buf += sent;
@@ -549,7 +561,7 @@ int conn_send_v2(conn_info_t *conn) {
             }
             if (errno == EPIPE || errno == ECONNRESET) {
                 dw_log("sendfile failed, connection closed by remote end conn_id=%d\n", conn_get_id_by_ptr(conn));
-                conn->status = CLOSE;
+                conn->status = CLOSING;
                 return -1;
             }
             fprintf(stderr, "SENDFILE error: %s\n", strerror(errno));

--- a/src/connection.h
+++ b/src/connection.h
@@ -57,6 +57,8 @@ typedef struct {
     
     int enable_defrag;            // Defragment receive buffer to reduce memory usage
 
+    int is_listen;                // 1 if this conn wraps a listening socket: not usable as a forward conn
+
 #ifdef DPDK_ENABLED
     struct rte_mbuf *rx_mbufs[RX_BURST_SIZE];
     struct rte_mbuf *tx_mbufs[TX_BURST_SIZE];

--- a/src/connection.h
+++ b/src/connection.h
@@ -21,7 +21,8 @@ typedef enum {
     SENDING,
     CONNECTING,    // used with TCP only
     SSL_HANDSHAKE, // used with SSL only
-    CLOSE,
+    CLOSING,
+    CLOSED,
     STATUS_NUMBER  // keep this as last
 } conn_status_t;
 

--- a/src/dw_client.c
+++ b/src/dw_client.c
@@ -513,7 +513,9 @@ void *thread_receiver(void *data) {
                 command_t *p_cmd = message_first_cmd(m);
                 if (p_cmd->cmd == EOM && m->req_size > msg_size) {
                     /* long REPLY case */
-                    command_t *p_next = cmd_next(p_cmd);
+                    command_t *p_next = cmd_bounded_next(p_cmd, message_end(m));
+                    if (!p_next)
+                        goto skip;
                     size_t diff = conn->curr_recv_buf - (unsigned char*)p_next;
                     m->req_size -= diff;
                     conn->curr_recv_buf -= diff;

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -829,26 +829,28 @@ int process_single_message(req_info_t *req, dw_poll_t *p_poll, conn_worker_info_
             }
             return 0;
         case REPLY:
-            dw_log("Handling REPLY: req_id=%d\n", m->req_id);
-            if (conn_get_status_by_id(req->conn_id) != CLOSE && !reply(req, m, cmd, infos)) {
-                dw_log("reply() returned, conn_id: %d\n", conn_id);
-                
+            dw_log("process_single_message: Handling REPLY: req_id=%d\n", m->req_id);
+            int reply_result = reply(req, m, cmd, infos);
+            dw_log("process_single_message: Handling REPLY: req_id=%d, we got reply_result:%d\n", m->req_id, reply_result);
+            if (conn_get_status_by_id(req->conn_id) != CLOSED && !reply_result) {
+                dw_log("process_single_message: reply() returned, conn_id: %d\n", conn_id);
+
                 if (conn_get_status_by_id(req->conn_id) == SENDING) {
-                    dw_log("Message req_id=%d is still sending after REPLY, conn_id: %d\n", m->req_id, conn_id);
+                    dw_log("process_single_message: Message req_id=%d is still sending after REPLY, conn_id: %d\n", m->req_id, conn_id);
                     sys_check(dw_poll_mod(p_poll, conns[req->conn_id].sock, DW_POLLOUT | DW_POLLONESHOT, i2l(SOCKET, conn_id)));
                     return 1;
                 } else {
-                    dw_log("Closing connection conn_id: %d after failed REPLY\n", conn_id);
+                    dw_log("process_single_message: Closing connection conn_id: %d after failed REPLY\n", conn_id);
                     close_and_forget(p_poll, conns[conn_id].sock);
                     return -1;
                 }
             }
             if (conn_get_status_by_id(req->conn_id) == SENDING) {
-
-                dw_log("Message req_id=%d is still sending after REPLY, conn_id: %d\n", m->req_id, conn_id);
+                dw_log("process_single_message:Message req_id=%d is still sending after REPLY, conn_id: %d\n", m->req_id, conn_id);
                 sys_check(dw_poll_mod(p_poll, conns[conn_id].sock, DW_POLLOUT | DW_POLLONESHOT, i2l(SOCKET, conn_id)));
             }
             // any further cmds[] for replied-to hop, not me
+            dw_log("process_single_message: case REPLY completed, with reply result: %d, will now return 1\n", reply_result);
             return 1;
         case STORE:
         case LOAD: {
@@ -1088,7 +1090,8 @@ void exec_request(dw_poll_t *p_poll, dw_poll_flags pflags, int conn_id, event_t 
     return;
 
  err:
-    if (conns->proto == TCP && conn_get_status(conn) == READY) {
+     dw_log("exec_request: entering goto err from conn_id=%d\n", conn_id);
+    if (conn->proto == TCP && conn_get_status(conn) == READY) {
         infos->active_conns--;
     }
     close_and_forget(p_poll, conn->sock);

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -327,7 +327,7 @@ void setnonblocking(int fd);
 
 // match_addr is 6 bytes: either fwd_host(4)+fwd_port(2) or fwd_addr[6],
 // same union in fwd_opts_t, so memcmp on fwd_addr covers both cases
-int find_forward_reply_id(command_t *cmd, const uint8_t match_addr[6]);
+int find_forward_reply_id(command_t *cmd, const uint8_t match_addr[6], void* msg_end);
 
 // cmd_id is the index of the FORWARD item within m->cmds[] here, we
 // remove the first (cmd_id+1) commands from cmds[], and forward the
@@ -343,19 +343,22 @@ command_t *single_start_forward(req_info_t *req, message_t *m, command_t *cmd, d
     addr.sin_addr.s_addr = fwd.fwd_host;
     addr.sin_port = fwd.fwd_port;
 
-    int fwd_reply_id = find_forward_reply_id(req->curr_cmd, fwd.fwd_addr);
+    void* msg_end = message_end(m);
+    int fwd_reply_id = find_forward_reply_id(req->curr_cmd, fwd.fwd_addr, msg_end);
     if (fwd_reply_id == -1)
         return NULL;
 
     if (req->fwd_replies_left != -1 && (req->fwd_replies_mask & (1 << fwd_reply_id))) {
         // avoid retransmissions of already acknowledged FORWARD branches
         dw_log("Found reply for fwd to: %s:%d\n", inet_ntoa((struct in_addr) {addr.sin_addr.s_addr}), ntohs(addr.sin_port));
-        cmd = cmd_next_forward(cmd);
+        void* msg_end = message_end(m);
+        cmd = cmd_bounded_next_forward(cmd, msg_end);
         if (cmd == NULL) {
-            cmd_log(cmd_skip(req->curr_cmd, 1));
+            //TODO: check what to do in this log tbh
+            cmd_log(cmd_bounded_skip(req->curr_cmd, 1, msg_end), msg_end);
         } else
-            cmd_log(cmd);
-        return cmd == NULL ? cmd_skip(req->curr_cmd, 1) : cmd;
+            cmd_log(cmd, msg_end);
+        return cmd == NULL ? cmd_bounded_skip(req->curr_cmd, 1, msg_end) : cmd;
     }
 #ifdef DPDK_ENABLED
     if (fwd.proto == DPDK) {
@@ -373,9 +376,10 @@ command_t *single_start_forward(req_info_t *req, message_t *m, command_t *cmd, d
         m_dst->req_size = fwd.pkt_size;
 
         // skip possible FORWARD_CONTINUE cmds in non-branched multi-fwd
-        command_t *c = cmd_next(cmd);
-        while (c->cmd == FORWARD_CONTINUE)
-            c = cmd_next(c);
+        void* dpdk_msg_end = message_end(m);
+        command_t *c = cmd_bounded_next(cmd, dpdk_msg_end);
+        while (c && c->cmd == FORWARD_CONTINUE)
+            c = cmd_bounded_next(c, dpdk_msg_end);
 
         command_t *reply_cmd = message_copy_tail(m, m_dst, c);
         if (!reply_cmd) {
@@ -471,9 +475,9 @@ command_t *single_start_forward(req_info_t *req, message_t *m, command_t *cmd, d
     assert(m_dst->req_size >= fwd.pkt_size);
 
     // skip possible FORWARD_CONTINUE cmds in non-branched multi-fwd
-    command_t *c = cmd_next(cmd);
-    while (c->cmd == FORWARD_CONTINUE)
-        c = cmd_next(c);
+    command_t *c = cmd_bounded_next(cmd, msg_end);
+    while (c && c->cmd == FORWARD_CONTINUE)
+        c = cmd_bounded_next(c, msg_end);
 
     command_t* reply_cmd = message_copy_tail(m, m_dst, c);
     if (!reply_cmd) {
@@ -514,10 +518,11 @@ command_t *start_forward(req_info_t *req, message_t *m, command_t *cmd, dw_poll_
     }
     
     command_t* itr = cmd;
+    void* msg_end = message_end(m);
     while (itr) {
         if (!single_start_forward(req, m, itr, p_poll, infos))
             return NULL;
-        itr = cmd_next_forward(itr);
+        itr = cmd_bounded_next_forward(itr, msg_end);
     }
     return cmd;
 }
@@ -528,9 +533,9 @@ int obtain_messages(int conn_id, dw_poll_t *p_poll, conn_worker_info_t* infos);
 // return 0-based id if found, or -1 if not found
 // match_addr is 6 bytes: either fwd_host(4)+fwd_port(2) or fwd_addr[6],
 // same union in fwd_opts_t, so memcmp on fwd_addr covers both cases
-int find_forward_reply_id(command_t *cmd, const uint8_t match_addr[6]) {
+int find_forward_reply_id(command_t *cmd, const uint8_t match_addr[6], void* msg_end) {
     int id = 0;
-    for (; cmd != NULL; cmd = cmd_next_forward(cmd), id++) {
+    for (; cmd != NULL; cmd = cmd_bounded_next_forward(cmd, msg_end), id++) {
         if (memcmp(cmd_get_opts(fwd_opts_t, cmd)->fwd_addr, match_addr, 6) == 0)
             return id;
     }
@@ -560,7 +565,9 @@ int handle_forward_reply(int req_id, dw_poll_t *p_poll, conn_worker_info_t* info
         snprintf(addr_str, sizeof(addr_str), "%s:%d", inet_ntoa(addr), ntohs(port));
     }
 
-    int reply_id = find_forward_reply_id(req->curr_cmd, match_addr);
+    message_t *req_m = req_get_message(req);
+    void *req_msg_end = message_end(req_m);
+    int reply_id = find_forward_reply_id(req->curr_cmd, match_addr, req_msg_end);
     dw_log("Found reply_id %d from: %s (conn_id: %d)\n", reply_id, addr_str, req->conn_id);
     if (reply_id == -1) {
         dw_log("Got a REPLY to FORWARD from an unexpected endpoint: %s - Dropped\n", addr_str);
@@ -574,8 +581,11 @@ int handle_forward_reply(int req_id, dw_poll_t *p_poll, conn_worker_info_t* info
 
     if (--(req->fwd_replies_left) <= 0) {
         message_t *m = req_get_message(req);
+        void *msg_end = message_end(req_m);
         m->status = fwd_m_status;
-        req->curr_cmd = cmd_skip(req->curr_cmd, 1);
+        req->curr_cmd = cmd_bounded_skip(req->curr_cmd, 1, msg_end);
+        if (req->curr_cmd == NULL)
+            dw_log("handle_forward_reply went out of bounds somewhere, on req_id:%d\n", req->req_id);
         
         // reply mask reset 
         req->fwd_replies_mask = 0;
@@ -811,8 +821,9 @@ void close_and_forget(dw_poll_t *p_poll, int sock) {
 int process_single_message(req_info_t *req, dw_poll_t *p_poll, conn_worker_info_t *infos) {
     message_t *m = req_get_message(req);
     int conn_id = req->conn_id;
+    void *msg_end = message_end(m);
 
-    for (command_t *cmd = req->curr_cmd; cmd->cmd != EOM; cmd = cmd_skip(cmd, 1)) {
+    for (command_t *cmd = req->curr_cmd; cmd && cmd->cmd != EOM; cmd = cmd_bounded_skip(cmd, 1, msg_end)) {
         dw_log("PROCESS conn_id: %d, req_id: %d,  command: %s\n", req->conn_id, req->req_id, get_command_name(cmd->cmd));
         switch(cmd->cmd) {
         case COMPUTE:
@@ -855,7 +866,7 @@ int process_single_message(req_info_t *req, dw_poll_t *p_poll, conn_worker_info_
         case STORE:
         case LOAD: {
             storage_req_t w = { .worker_id = infos->worker_id, .req_id = req->req_id };
-            int cmds_len = ((unsigned char*)cmd_next(cmd) - (unsigned char*)cmd);
+            int cmds_len = cmd_type_size(cmd->cmd);
             memcpy(&w.cmd, cmd, cmds_len);
 
             // determine which storage worker to use based on store/load option device id, and send the request to it
@@ -876,7 +887,7 @@ int process_single_message(req_info_t *req, dw_poll_t *p_poll, conn_worker_info_
             if (cmd->cmd == STORE && !cmd_get_opts(store_opts_t, cmd)->wait_sync)
                 break;
 
-            req->curr_cmd = cmd_next(cmd);
+            req->curr_cmd = cmd_bounded_next(cmd, msg_end);
             return 0;
         }
         default:
@@ -1007,7 +1018,7 @@ void handle_timeout(dw_poll_t *p_poll, conn_worker_info_t *infos) {
     } else if (req->fwd_on_fail_skip > 0) {
         dw_log("TIMEOUT expired, req_id: %d, failed, skipping: %d\n", req->req_id, req->fwd_on_fail_skip);
         
-        req->curr_cmd = cmd_skip(req->curr_cmd, req->fwd_on_fail_skip);
+        req->curr_cmd = cmd_bounded_skip(req->curr_cmd, req->fwd_on_fail_skip, message_end(m));
         m->status = TIMEOUT;
         process_messages(req, p_poll, infos);
     } else {
@@ -1118,10 +1129,11 @@ void exec_request(dw_poll_t *p_poll, dw_poll_flags pflags, int conn_id, event_t 
                         
                     // Go to last REPLY
                     command_t *itr = tmp->curr_cmd;
-                    while (itr->cmd != EOM && itr->cmd != REPLY)
-                        itr = cmd_skip(tmp->curr_cmd, 1);
+                    void *msg_end = message_end(m);
+                    while (itr && itr->cmd != EOM && itr->cmd != REPLY)
+                        itr = cmd_bounded_skip(itr, 1, msg_end);
 
-                    if (itr->cmd == EOM) { // brutal
+                    if (!itr || !cmd_in_bounds(itr, msg_end) || itr->cmd == EOM) { // brutal
                         close_and_forget(p_poll, pending_conn->sock);
                     } else { // graceful
                         tmp->curr_cmd = itr;

--- a/src/dw_node.c
+++ b/src/dw_node.c
@@ -1318,9 +1318,11 @@ void* conn_worker(void* args) {
             int s = infos->listen_socks[i];
             if (s < 0) continue;
             int conn_id = conn_find_sock(s);
+            conn_info_t *conn = conn_get_by_id(conn_id);
+            assert(conn);
 
             uint64_t aux;
-            if(conn_id == -1) // TCP/TLS
+            if (conn->proto == TCP || conn->proto == TLS)
                 aux = i2l(LISTEN, s);
             else // UDP
                 aux = i2l(SOCKET, conn_id);
@@ -1821,11 +1823,15 @@ void init_listen_sock(int i, accept_mode_t accept_mode, proto_t proto, struct so
             sys_check(lsock = socket(AF_INET, SOCK_STREAM, 0));
         } else {
             sys_check(lsock = socket(AF_INET, SOCK_DGRAM, 0));
-            int conn_id = conn_alloc(lsock, serverAddr, UDP);
-            check(conn_id != -1, "conn_alloc() failed, terminating!");
-            conn_set_status_by_id(conn_id, READY);
-            conn_get_by_id(conn_id)->enable_defrag = enable_defrag;
         }
+        int conn_id = conn_alloc(lsock, serverAddr, proto);
+        check(conn_id != -1, "conn_alloc() failed, terminating!");
+        conn_set_status_by_id(conn_id, READY);
+        conn_get_by_id(conn_id)->enable_defrag = enable_defrag;
+        // TCP/TLS listen sockets must be excluded from conn_find_existing(), a UDP socket is shared
+        if (proto == TCP || proto == TLS)
+            conn_get_by_id(conn_id)->is_listen = 1;
+
         int val = 1;
         sys_check(setsockopt(lsock, SOL_SOCKET, SO_REUSEADDR, (void *)&val, sizeof(val)));
         if (accept_mode == AM_CHILD)

--- a/src/message.c
+++ b/src/message.c
@@ -66,50 +66,87 @@ inline int cmd_type_size(command_type_t type) {
     return base;
 }
 
-// Move to the next command
-inline command_t* cmd_next(command_t *cmd) {
+
+// Move to the next command;
+// returns NULL if that would put you out of bounds
+inline command_t* cmd_bounded_next(command_t *cmd, void* msg_end) {
     unsigned char *ptr = (unsigned char*)cmd;
-    return (command_t*) (ptr + cmd_type_size(cmd->cmd));
+    command_t* would_be_next = (command_t*) (ptr + cmd_type_size(cmd->cmd));
+    return (cmd_in_bounds(would_be_next, msg_end)) ? would_be_next : NULL;
 }
 
 // Skip to_skip contextes (i.e., a simple operation, or a collection of operation within a forward scope)
-command_t* cmd_skip(command_t *cmd, int to_skip) {
+//  If skipping would push out of message bounds, return NULL
+command_t* cmd_bounded_skip(command_t *cmd, int to_skip, void* msg_end) {
+    if (!cmd || !cmd_in_bounds(cmd, msg_end)) {
+        return NULL;
+    }
+    
+    // Since all following values of <cmd> are set via <cmd_bounded_next> and it is checked, 
+    // now we can be sure that (cmd && cmd_in_bounds(cmd, msg_end)) is true, 
+    // and thus we don't need that condition in the <while> nor in the <do while>.
+    command_t* would_be_next = NULL;
     while (cmd->cmd != EOM && to_skip > 0) {
         int nested_fwd = 0;
         do {
+            would_be_next = cmd_bounded_next(cmd, msg_end);
+            if (!would_be_next) {
+                return NULL;
+            }
             if (cmd->cmd == FORWARD_BEGIN) {
                 nested_fwd++;
             } else if (cmd->cmd == FORWARD_CONTINUE) {
                 /* skip multiple (non-branching) FORWARD_CONTINUE following FORWARD_BEGIN */
             } else if (cmd->cmd == REPLY) {
-                if (cmd_next(cmd)->cmd != FORWARD_CONTINUE) // must have branched=1
+                if (would_be_next->cmd != FORWARD_CONTINUE) // must have branched=1
                     nested_fwd--;
             }
-            cmd = cmd_next(cmd);
+            cmd = would_be_next;
         } while (cmd->cmd != EOM && nested_fwd > 0);
         to_skip--;
     }
-
-    return cmd;
+    if (to_skip > 0) {
+        // this should never happen.
+        return NULL;
+    }else{
+        return cmd;
+    }
 }
 
 // return next FORWARD in the same multi-FORWARD context, or NULL if there are none
-command_t* cmd_next_forward(command_t *cmd) {
+//  returns NULL also if search leads out of message bounds.
+command_t* cmd_bounded_next_forward(command_t *cmd, void* msg_end) {
+    if (!cmd || !cmd_in_bounds(cmd, msg_end)) {
+        return NULL;
+    }
     check(cmd->cmd == FORWARD_CONTINUE || cmd->cmd == FORWARD_BEGIN);
 
     int branched = cmd_get_opts(fwd_opts_t, cmd)->branched;
-    cmd = cmd_next(cmd);
-    while (cmd->cmd != EOM && cmd->cmd != FORWARD_CONTINUE) {
+    cmd = cmd_bounded_next(cmd, msg_end);
+    command_t* would_be_next = NULL;
+    // cmd is updated via <cmd_bounded_skip> or <cmd_bounded_next>, hence we need to check (cmd!=NULL).
+    while (cmd && cmd->cmd != EOM && cmd->cmd != FORWARD_CONTINUE) {
         if (cmd->cmd == FORWARD_BEGIN)
-            cmd = cmd_skip(cmd, 1);
-        else if (cmd->cmd == REPLY && (!branched || cmd_next(cmd)->cmd != FORWARD_CONTINUE))
-            // when branched, a REPLY is followed by a CONTINUE, or the FORWARD context is over;
-            // when !branched, a REPLY terminates the FORWARD context
-            return NULL;
-        else
-            cmd = cmd_next(cmd);
+            cmd = cmd_bounded_skip(cmd, 1, msg_end);
+        else {
+            would_be_next = cmd_bounded_next(cmd, msg_end);
+            if (!would_be_next) {
+                return NULL;
+            }
+            if (cmd->cmd == REPLY && (!branched || would_be_next->cmd != FORWARD_CONTINUE)) {
+                // when branched, a REPLY is followed by a CONTINUE, or the FORWARD context is over;
+                // when !branched, a REPLY terminates the FORWARD context
+                return NULL;
+            } else {
+                cmd = would_be_next;
+            }
+        }
     }
-    return cmd;
+    if (cmd && cmd_in_bounds(cmd, msg_end) && cmd->cmd == FORWARD_CONTINUE) {
+        return cmd;
+    }else{
+        return NULL;
+    }
 }
 
 inline command_t* message_first_cmd(message_t *m) {
@@ -124,11 +161,17 @@ command_t* message_copy_tail(message_t *m, message_t *m_dst, command_t *cmd) {
     m_dst->req_id = m->req_id;
 
     // find matching reply
+    void *msg_end = message_end(m);
     command_t *itr = cmd;
-    while (itr->cmd != EOM && itr->cmd != REPLY)
-        itr = cmd_skip(itr, 1);
-    //assert(itr->cmd != EOM);
-    int cmds_len = ((unsigned char*)cmd_next(itr) - (unsigned char*)cmd);
+    while (itr && itr->cmd != EOM && itr->cmd != REPLY) {
+        itr = cmd_bounded_skip(itr, 1, msg_end);
+    }
+    
+    if (!itr || !cmd_in_bounds(itr, msg_end)) {
+        return NULL;
+    }
+
+    int cmds_len = ((unsigned char*)itr + cmd_type_size(itr->cmd)) - (unsigned char*)cmd;
 
     command_t * dst_itr = message_first_cmd(m_dst);
     if (m_dst->req_size < cmds_len + cmd_type_size(EOM)) // Check if enough space for EOM delimiter
@@ -138,15 +181,15 @@ command_t* message_copy_tail(message_t *m, message_t *m_dst, command_t *cmd) {
     command_t* end_command = (command_t*)((unsigned char*)dst_itr + cmds_len);
     end_command->cmd = EOM;
     
-    m_dst->req_size = (unsigned char*)cmd_next(end_command) - (unsigned char*)m_dst;
+    m_dst->req_size = ((unsigned char*)end_command + cmd_type_size(end_command->cmd)) - (unsigned char*)m_dst;
     //int skipped_len = ((unsigned char*)cmd - (unsigned char*)message_first_cmd(m));
     //m_dst->req_size = min(m_dst->req_size, m->req_size - skipped_len);
     return itr;
 }
 
-inline const void cmd_log(command_t* cmd) {
+inline const void cmd_log(command_t* cmd, void* msg_end) {
     command_t *c = cmd, *pre_c;
-    while (c->cmd != EOM) {
+    while (c && cmd_in_bounds(c, msg_end) && c->cmd != EOM) {
         char opts[256] = "";
 
         switch (c->cmd) {
@@ -182,7 +225,7 @@ inline const void cmd_log(command_t* cmd) {
             exit(EXIT_FAILURE);
         }
         pre_c = c;
-        c = cmd_next(c);
+        c = cmd_bounded_next(c, msg_end);
         printf("%s(%s)%s", get_command_name(pre_c->cmd), opts, "->");
     }
     printf("EOM");
@@ -192,5 +235,5 @@ inline const void cmd_log(command_t* cmd) {
 inline const void msg_log(message_t* m, char* padding) {
     printf("%s", padding);
     printf("message (req_id: %u, req_size: %u, num: %u, status: %s): ", m->req_id, m->req_size, msg_num_cmd(m), msg_status_str(m->status));
-    cmd_log(message_first_cmd(m));
+    cmd_log(message_first_cmd(m), message_end(m));
 }

--- a/src/message.h
+++ b/src/message.h
@@ -1,6 +1,7 @@
 #ifndef __MESSAGE_H__
 #define __MESSAGE_H__
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -84,23 +85,41 @@ const char* get_command_name(command_type_t cmd);
 
 command_t* message_copy_tail(message_t *m, message_t *m_dst, command_t *cmd);
 
-command_t* cmd_next(command_t *cmd);
-command_t* cmd_skip(command_t *cmd, int to_skip);
-command_t* cmd_next_forward(command_t *cmd);
+command_t* cmd_bounded_next(command_t *cmd, void* msg_end);
+command_t* cmd_bounded_skip(command_t *cmd, int to_skip, void* msg_end);
+command_t* cmd_bounded_next_forward(command_t *cmd, void* msg_end);
 
 command_t* message_first_cmd(message_t *m);
 int cmd_type_size(command_type_t type);
 
+static inline void* message_end(message_t *m) {
+    return (char*)m + m->req_size;
+}
+
+// true if the command at cmd is in bounds of the message
+static inline bool cmd_in_bounds(command_t *cmd, void *msg_end) {
+    const char *start = (char*)cmd;
+    const char *end = msg_end;
+
+    // the header must be in bounds before we can read cmd->cmd
+    if (start + sizeof(command_t) > end)
+        return false;
+
+    // then the opts need to be in bounds
+    return start + cmd_type_size(cmd->cmd) <= end;
+}
+
 static inline int msg_num_cmd(message_t *m) {
     int n = 0;
     command_t *cmd = message_first_cmd(m);
-    while ((char*)cmd - (char*)m < m->req_size && cmd->cmd != EOM) {
+    void* msg_end = message_end(m);
+    while (cmd && cmd_in_bounds(cmd, msg_end) && cmd->cmd != EOM) {
         n++;
-        cmd = cmd_next(cmd);
+        cmd = cmd_bounded_next(cmd, msg_end);
     }
     return n;
 }
 
 const void msg_log(message_t* m, char* padding);
-const void cmd_log(command_t* c);
+const void cmd_log(command_t* c, void* msg_end);
 #endif /* __MESSAGE_H__ */

--- a/src/test_ccmd.c
+++ b/src/test_ccmd.c
@@ -366,27 +366,28 @@ bool test_ccmd_dump_1() {
     ccmd_dump(ccmd, m);
 
     bool res = false;
+    void *msg_end = message_end(m);
 
     command_t *c = message_first_cmd(m);
-    if (c->cmd != STORE) {
+    if (!c || c->cmd != STORE) {
         res = false;
         goto err;
     }
 
-    c = cmd_next(c);
-    if (c->cmd != COMPUTE) {
+    c = cmd_bounded_next(c, msg_end);
+    if (!c || c->cmd != COMPUTE) {
         res = false;
         goto err;
     }
 
-    c = cmd_next(c);
-    if (c->cmd != REPLY && cmd_get_opts(reply_opts_t, c)->resp_size == 900) {
+    c = cmd_bounded_next(c, msg_end);
+    if (!c || (c->cmd != REPLY && cmd_get_opts(reply_opts_t, c)->resp_size == 900)) {
         res = false;
         goto err;
     }
 
-    c = cmd_next(c);
-    if (c->cmd != EOM) {
+    c = cmd_bounded_next(c, msg_end);
+    if (!c || c->cmd != EOM) {
         res = false;
         goto err;
     }

--- a/src/test_message.c
+++ b/src/test_message.c
@@ -9,24 +9,25 @@ bool test_message_construct() {
     message_t *m = (message_t *) calloc(BUF_SIZE, sizeof(unsigned char));
     m->req_size = BUF_SIZE;
     m->req_id = 0;
+    void *msg_end = message_end(m);
 
     command_t *c_itr = message_first_cmd(m);
     c_itr->cmd = COMPUTE;
     cmd_get_opts(comp_opts_t, c_itr)->comp_time_us = 1000;
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = COMPUTE;
     cmd_get_opts(comp_opts_t, c_itr)->comp_time_us = 2000;
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = EOM;
 
     //invalid
-    c_itr  = cmd_next(c_itr);
+    c_itr  = cmd_bounded_next(c_itr, msg_end);
     cmd_get_opts(comp_opts_t, c_itr)->comp_time_us = -1;
 
     if (msg_num_cmd(m) != 2)
         goto err;
 
-    for (command_t *itr = message_first_cmd(m); itr->cmd != EOM; itr = cmd_next(itr)) {
+    for (command_t *itr = message_first_cmd(m); itr && itr->cmd != EOM; itr = cmd_bounded_next(itr, msg_end)) {
         int comp_us = cmd_get_opts(comp_opts_t, itr)->comp_time_us;
         if (itr->cmd != COMPUTE || (comp_us != 1000 && comp_us != 2000))
             goto err;
@@ -45,31 +46,33 @@ bool test_message_copy_no_append() {
     message_t *m = (message_t *) calloc(BUF_SIZE, sizeof(unsigned char));
     m->req_size = BUF_SIZE;
     m->req_id = 0;
+    void *msg_end = message_end(m);
 
     command_t *c_itr = message_first_cmd(m);
     cmd_get_opts(comp_opts_t, c_itr)->comp_time_us = 1000;
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     cmd_get_opts(comp_opts_t, c_itr)->comp_time_us = 2000;
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = EOM;
 
     /* coverity[suspicious_sizeof] */
     message_t *m_dst = (message_t *) malloc(BUF_SIZE);
     m_dst->req_size = BUF_SIZE;
+    void *msg_end_dst = message_end(m_dst);
     message_first_cmd(m_dst)->cmd = EOM;
     
     if (!message_copy_tail(m, m_dst, message_first_cmd(m)))
         goto err;
     if (msg_num_cmd(m_dst) != 2)
         goto err;
-    for (command_t *itr = message_first_cmd(m_dst); itr->cmd != EOM; itr = cmd_next(itr)) {
+    for (command_t *itr = message_first_cmd(m_dst); itr && itr->cmd != EOM; itr = cmd_bounded_next(itr, msg_end_dst)) {
         int comp_us = cmd_get_opts(comp_opts_t, itr)->comp_time_us;
         if (itr->cmd != COMPUTE || (comp_us != 1000 && comp_us != 2000))
             goto err;
     }
 
 
-    if (!message_copy_tail(m, m_dst, cmd_next(message_first_cmd(m))))
+    if (!message_copy_tail(m, m_dst, cmd_bounded_next(message_first_cmd(m), msg_end)))
         goto err;
     if (msg_num_cmd(m_dst) != 1)
         goto err;
@@ -93,21 +96,23 @@ bool test_message_copy_with_reply() {
     message_t *m = (message_t *) (message_t *) calloc(BUF_SIZE, sizeof(unsigned char));;
     m->req_size = BUF_SIZE;
     m->req_id = 0;
+    void *msg_end = message_end(m);
 
     command_t *c_itr = message_first_cmd(m);
     cmd_get_opts(comp_opts_t, c_itr)->comp_time_us = 1000;
     c_itr->cmd = COMPUTE;
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = REPLY;
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = COMPUTE;
     cmd_get_opts(comp_opts_t, c_itr)->comp_time_us = 2000;
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = EOM;
 
     /* coverity[suspicious_sizeof] */
     message_t *m_dst = (message_t *) malloc(BUF_SIZE);
     m_dst->req_size = BUF_SIZE;
+    void *msg_end_dst = message_end(m_dst);
     message_first_cmd(m_dst)->cmd = EOM;
 
     if (!message_copy_tail(m, m_dst, message_first_cmd(m)))
@@ -115,7 +120,7 @@ bool test_message_copy_with_reply() {
     if (msg_num_cmd(m_dst) != 2)
         goto err;
     
-    for (command_t *itr = message_first_cmd(m_dst); itr->cmd != EOM; itr = cmd_next(itr)) {
+    for (command_t *itr = message_first_cmd(m_dst); itr && itr->cmd != EOM; itr = cmd_bounded_next(itr, msg_end_dst)) {
         int comp_us = cmd_get_opts(comp_opts_t, itr)->comp_time_us;
         if (itr->cmd != REPLY && (itr->cmd == COMPUTE && comp_us != 1000))
             goto err;
@@ -136,56 +141,58 @@ bool test_message_copy_fragment() {
     message_t *m = (message_t *) calloc(BUF_SIZE, sizeof(unsigned char));
     m->req_size = BUF_SIZE;
     m->req_id = 0;
+    void *msg_end = message_end(m);
 
     command_t *c_itr = message_first_cmd(m);
     c_itr->cmd = FORWARD_BEGIN;
     cmd_get_opts(fwd_opts_t, c_itr)->branched = 1;
 
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = STORE;
     cmd_get_opts(store_opts_t, c_itr)->store_nbytes = 1000;
 
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = REPLY;
 
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = FORWARD_CONTINUE;
     cmd_get_opts(fwd_opts_t, c_itr)->branched = 1;
 
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = LOAD;
     cmd_get_opts(load_opts_t, c_itr)->load_nbytes = 2000;
 
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = REPLY;
 
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     cmd_get_opts(comp_opts_t, c_itr)->comp_time_us = 3000;
 
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = REPLY;
 
-    c_itr = cmd_next(c_itr);
+    c_itr = cmd_bounded_next(c_itr, msg_end);
     c_itr->cmd = EOM;
 
     /* coverity[suspicious_sizeof] */
     message_t *m_branch1 = (message_t *) calloc(BUF_SIZE, sizeof(unsigned char));
     m_branch1->req_size = BUF_SIZE;
+    void *msg_end_branch = message_end(m_branch1);
     m->req_id = 0;
     
-    command_t *c = cmd_next(message_first_cmd(m));
-    while (c->cmd != EOM && c->cmd == FORWARD_CONTINUE)
-        c = cmd_next(c);
+    command_t *c = cmd_bounded_next(message_first_cmd(m), msg_end);
+    while (c && c->cmd != EOM && c->cmd == FORWARD_CONTINUE)
+        c = cmd_bounded_next(c, msg_end);
     if (!message_copy_tail(m, m_branch1, c))
         goto err;
 
     // check
     c_itr = message_first_cmd(m_branch1);
 
-    if (c_itr->cmd != STORE)
+    if (!c_itr || c_itr->cmd != STORE)
         goto err;
-    c_itr = cmd_next(c_itr);
-    if (c_itr->cmd != REPLY)
+    c_itr = cmd_bounded_next(c_itr, msg_end_branch);
+    if (!c_itr || c_itr->cmd != REPLY)
         goto err;
 
     free(m);


### PR DESCRIPTION
Each commit describes the changes.
Mostly, we extensively enforce boundary checking on logic and pointer arithmetic.
This proves useful e.g.when testing resistance against malformed or malsized messages.


